### PR TITLE
[Build Number] Use a dedicated shared value for build number

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Only create a GH release if triggered on CI
 | Key & Env Var | Description | Default Value
 |-----------------|--------------------|---|
 | `short_version_string` <br/> NONE | The short version string (eg: 0.2.6) | `Actions.lane_context[SharedValues::SHORT_VERSION_STRING]` | |
-| `build_number` <br/> NONE | The build number (eg: 625) | `Actions.lane_context[SharedValues::BUILD_NUMBER]` |
+| `build_number` <br/> NONE | The build number (eg: 625) | `Actions.lane_context[SharedValues::FUELED_BUILD_NUMBER]` |
 | `build_config` <br/> `BUILD_CONFIGURATION` | The build configuration (eg: Debug) | `Debug` |
 | `repository_name` <br/> `REPOSITORY_NAME` | The repository name (eg: fueled/zenni-ios) | |
 | `github_token` <br/> `GITHUB_TOKEN` | A Github Token to interact with the GH APIs | |
@@ -165,7 +165,7 @@ Only create a GH release if triggered on CI
 
 Sets the new build version name and build number as shared values.
 
-This action sets shared values for build number (`SharedValues::BUILD_NUMBER`) and build version name (`SharedValues::SHORT_VERSION_STRING`).
+This action sets shared values for build number (`SharedValues::FUELED_BUILD_NUMBER`) and build version name (`SharedValues::SHORT_VERSION_STRING`).
 Your Fastfile should use these values in a next step to set them to the project accordingly (set_app_versions_android or set_app_versions_android).
 
 | Key & Env Var | Description | Default Value
@@ -176,7 +176,7 @@ Your Fastfile should use these values in a next step to set them to the project 
 
 Sets the new CFBundleVersion and CFBundleShortVersion as shared values, without setting them in the project.
 
-This action sets shared values for `CFBundleVersion` (`SharedValues::BUILD_NUMBER`) and `CFBundleShortVersion` (`SharedValues::SHORT_VERSION_STRING`).
+This action sets shared values for `CFBundleVersion` (`SharedValues::FUELED_BUILD_NUMBER`) and `CFBundleShortVersion` (`SharedValues::SHORT_VERSION_STRING`).
 
 Your Fastfile should use these values in a next step to set them to the project accordingly (`set_app_versions_xcodeproj_ios` or `set_app_versions_plist_ios`).
 
@@ -227,7 +227,7 @@ Update the Android app version using the passed parameters.
 | Key & Env Var | Description | Default Value
 |-----------------|--------------------|---|
 | `short_version_string` | The short version string (eg: 0.2.6) | `SharedValues::SHORT_VERSION_STRING` |
-| `build_number` <br/> `BUILD_NUMBER` | The build number (eg: 625) | `SharedValues::BUILD_NUMBER` |
+| `build_number` <br/> `BUILD_NUMBER` | The build number (eg: 625) | `SharedValues::FUELED_BUILD_NUMBER` |
 
 #### `set_app_versions_plist_ios`
 Update the iOS app versions in the plist file (`CFBundleVersion` & `CFShortBundleVersion`) using the passed parameters.
@@ -237,7 +237,7 @@ Update the iOS app versions in the plist file (`CFBundleVersion` & `CFShortBundl
 | `project_path` <br/> `PROJECT_PATH` | The path to the project .xcodeproj |  |
 | `build_config` <br/> `BUILD_CONFIGURATION` | The build configuration (eg: Debug) | |
 | `short_version_string` | The short version string (eg: 0.2.6) | `SharedValues::SHORT_VERSION_STRING` |
-| `build_number` <br/> `BUILD_NUMBER` | The build number (eg: 625) | `SharedValues::BUILD_NUMBER` |
+| `build_number` <br/> `BUILD_NUMBER` | The build number (eg: 625) | `SharedValues::FUELED_BUILD_NUMBER` |
 
 #### `set_app_versions_xcodeproj_ios`
 Update the iOS app versions in the xcodeproj (`CFBundleVersion` & `CFShortBundleVersion`) using the passed parameters.
@@ -247,7 +247,7 @@ Update the iOS app versions in the xcodeproj (`CFBundleVersion` & `CFShortBundle
 | `project_path` <br/> `PROJECT_PATH` | The path to the project .xcodeproj |  |
 | `build_config` <br/> `BUILD_CONFIGURATION` | The build configuration (eg: Debug) | |
 | `short_version_string` | The short version string (eg: 0.2.6) | `SharedValues::SHORT_VERSION_STRING` |
-| `build_number` <br/> `BUILD_NUMBER` | The build number (eg: 625) | `SharedValues::BUILD_NUMBER` |
+| `build_number` <br/> `BUILD_NUMBER` | The build number (eg: 625) | `SharedValues::FUELED_BUILD_NUMBER` |
 
 #### `tag`
 Tag the version using the following pattern : `v[short_version]#[build_number]-[build_config]`
@@ -258,7 +258,7 @@ Note that tagging happens only on CI
 |-----------------|--------------------|---|
 | `build_config` <br/> `BUILD_CONFIGURATION` | The build configuration (eg: Debug) | |
 | `short_version_string` | The short version string (eg: 0.2.6) | `SharedValues::SHORT_VERSION_STRING` |
-| `build_number` <br/> `BUILD_NUMBER` | The build number (eg: 625) | `SharedValues::BUILD_NUMBER` |
+| `build_number` <br/> `BUILD_NUMBER` | The build number (eg: 625) | `SharedValues::FUELED_BUILD_NUMBER` |
 
 ## Issues and Feedback
 

--- a/lib/fastlane/plugin/fueled/actions/create_github_release.rb
+++ b/lib/fastlane/plugin/fueled/actions/create_github_release.rb
@@ -47,7 +47,7 @@ module Fastlane
             key: :build_number,
             description: "The build number (eg: 625)",
             optional: true,
-            default_value: Actions.lane_context[SharedValues::BUILD_NUMBER]
+            default_value: Actions.lane_context[SharedValues::FUELED_BUILD_NUMBER]
           ),
           FastlaneCore::ConfigItem.new(
             key: :build_config,

--- a/lib/fastlane/plugin/fueled/actions/define_versions_android.rb
+++ b/lib/fastlane/plugin/fueled/actions/define_versions_android.rb
@@ -4,13 +4,13 @@ module Fastlane
   module Actions
     module SharedValues
       SHORT_VERSION_STRING = :SHORT_VERSION_STRING
-      BUILD_NUMBER = :BUILD_NUMBER
+      FUELED_BUILD_NUMBER = :FUELED_BUILD_NUMBER
     end
 
     class DefineVersionsAndroidAction < Action
       def self.run(params)
         # Build Number
-        Actions.lane_context[SharedValues::BUILD_NUMBER] = Helper::FueledHelper.new_build_number
+        Actions.lane_context[SharedValues::FUELED_BUILD_NUMBER] = Helper::FueledHelper.new_build_number
         # Short Version
         current_short_version = Helper::FueledHelper.short_version_from_tag
         if current_short_version.split('.').first.to_i >= 1
@@ -35,7 +35,7 @@ module Fastlane
 
       def self.details
         "
-        This action sets shared values for build number (SharedValues::BUILD_NUMBER) and build version name (SharedValues::SHORT_VERSION_STRING).
+        This action sets shared values for build number (SharedValues::FUELED_BUILD_NUMBER) and build version name (SharedValues::SHORT_VERSION_STRING).
         Your Fastfile should use these values in a next step to set them to the project accordingly (set_app_versions_android or set_app_versions_android).
         "
       end
@@ -60,7 +60,7 @@ module Fastlane
       def self.output
         [
           ['SHORT_VERSION_STRING', 'The short version that should be set'],
-          ['BUILD_NUMBER', 'The new build number that should be set']
+          ['FUELED_BUILD_NUMBER', 'The new build number that should be set']
         ]
       end
 

--- a/lib/fastlane/plugin/fueled/actions/define_versions_ios.rb
+++ b/lib/fastlane/plugin/fueled/actions/define_versions_ios.rb
@@ -4,13 +4,13 @@ module Fastlane
   module Actions
     module SharedValues
       SHORT_VERSION_STRING = :SHORT_VERSION_STRING
-      BUILD_NUMBER = :BUILD_NUMBER
+      FUELED_BUILD_NUMBER = :FUELED_BUILD_NUMBER
     end
 
     class DefineVersionsIosAction < Action
       def self.run(params)
         # Build Number
-        Actions.lane_context[SharedValues::BUILD_NUMBER] = Helper::FueledHelper.new_build_number
+        Actions.lane_context[SharedValues::FUELED_BUILD_NUMBER] = Helper::FueledHelper.new_build_number
         # Short Version
         current_short_version = Helper::FueledHelper.short_version_ios(project_path: params[:project_path])
         if current_short_version.split('.').first.to_i >= 1
@@ -35,7 +35,7 @@ module Fastlane
 
       def self.details
         "
-        This action sets shared values for CFBundleVersion (SharedValues::BUILD_NUMBER) and CFBundleShortVersion (SharedValues::SHORT_VERSION_STRING).
+        This action sets shared values for CFBundleVersion (SharedValues::FUELED_BUILD_NUMBER) and CFBundleShortVersion (SharedValues::SHORT_VERSION_STRING).
         Your Fastfile should use these values in a next step to set them to the project accordingly (set_app_versions_xcodeproj_ios or set_app_versions_plist_ios).
         "
       end
@@ -67,7 +67,7 @@ module Fastlane
       def self.output
         [
           ['SHORT_VERSION_STRING', 'The short version that should be set'],
-          ['BUILD_NUMBER', 'The new build number that should be set']
+          ['FUELED_BUILD_NUMBER', 'The new build number that should be set']
         ]
       end
 

--- a/lib/fastlane/plugin/fueled/actions/set_app_versions_android.rb
+++ b/lib/fastlane/plugin/fueled/actions/set_app_versions_android.rb
@@ -5,7 +5,7 @@ module Fastlane
     class SetAppVersionsAndroidAction < Action
       def self.run(params)
         ENV['BUILD_VERSION_NAME'] = params[:short_version_string]
-        ENV['BUILD_NUMBER'] = params[:build_number]
+        ENV['FUELED_BUILD_NUMBER'] = params[:build_number]
       end
 
       #####################################################
@@ -33,7 +33,7 @@ module Fastlane
             env_name: "BUILD_NUMBER",
             description: "The build number (eg: 625)",
             optional: true,
-            default_value: Actions.lane_context[SharedValues::BUILD_NUMBER]
+            default_value: Actions.lane_context[SharedValues::FUELED_BUILD_NUMBER]
           )
         ]
       end

--- a/lib/fastlane/plugin/fueled/actions/set_app_versions_plist_ios.rb
+++ b/lib/fastlane/plugin/fueled/actions/set_app_versions_plist_ios.rb
@@ -48,7 +48,7 @@ module Fastlane
             key: :build_number,
             description: "The build number (eg: 625)",
             optional: true,
-            default_value: Actions.lane_context[SharedValues::BUILD_NUMBER]
+            default_value: Actions.lane_context[SharedValues::FUELED_BUILD_NUMBER]
           )
         ]
       end

--- a/lib/fastlane/plugin/fueled/actions/set_app_versions_xcodeproj_ios.rb
+++ b/lib/fastlane/plugin/fueled/actions/set_app_versions_xcodeproj_ios.rb
@@ -48,7 +48,7 @@ module Fastlane
             key: :build_number,
             description: "The build number (eg: 625)",
             optional: true,
-            default_value: Actions.lane_context[SharedValues::BUILD_NUMBER]
+            default_value: Actions.lane_context[SharedValues::FUELED_BUILD_NUMBER]
           )
         ]
       end

--- a/lib/fastlane/plugin/fueled/actions/tag.rb
+++ b/lib/fastlane/plugin/fueled/actions/tag.rb
@@ -44,7 +44,7 @@ module Fastlane
             key: :build_number,
             description: "The build number (eg: 625)",
             optional: false,
-            default_value: Actions.lane_context[SharedValues::BUILD_NUMBER]
+            default_value: Actions.lane_context[SharedValues::FUELED_BUILD_NUMBER]
           ),
           FastlaneCore::ConfigItem.new(
             key: :build_config,


### PR DESCRIPTION
### Fix
* As observed by @robdeans , the build config was duplicated in the tag name. It appears some [other actions](https://github.com/SiarheiFedartsou/fastlane-plugin-versioning/blob/ff089f0f97c99d9769a3039c47de11b3aad4549d/lib/fastlane/plugin/versioning/actions/increment_build_number_in_xcodeproj.rb#L29) were messing around with the shared `BUILD_NUMBER` value.