### PR TITLE
Fix android specific actions

### DIFF
--- a/lib/fastlane/plugin/fueled/actions/define_versions_android.rb
+++ b/lib/fastlane/plugin/fueled/actions/define_versions_android.rb
@@ -69,7 +69,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include?(platform)
+        [:android].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/fueled/actions/generate_changelog.rb
+++ b/lib/fastlane/plugin/fueled/actions/generate_changelog.rb
@@ -27,7 +27,12 @@ module Fastlane
     class GenerateChangelogAction < Action
       def self.git_retrieve_commits(revision1, revision2)
         git_format = $git_format_info.map { |info| $git_format_selectors[info] }.join("\t")
-        return `git log --no-merges "#{revision1}"..#{revision2} --format=\"#{git_format}\" | tail -r`
+        
+        if FastlaneCore::Helper.linux?
+          return `git log --no-merges "#{revision1}"..#{revision2} --format=\"#{git_format}\" | tac`
+        else
+          return `git log --no-merges "#{revision1}"..#{revision2} --format=\"#{git_format}\" | tail -r`
+        end
       end
 
       def self.run(params)

--- a/lib/fastlane/plugin/fueled/actions/set_app_versions_android.rb
+++ b/lib/fastlane/plugin/fueled/actions/set_app_versions_android.rb
@@ -5,7 +5,7 @@ module Fastlane
     class SetAppVersionsAndroidAction < Action
       def self.run(params)
         ENV['BUILD_VERSION_NAME'] = params[:short_version_string]
-        ENV['FUELED_BUILD_NUMBER'] = params[:build_number]
+        ENV['FUELED_BUILD_NUMBER'] = params[:build_number].to_s
       end
 
       #####################################################


### PR DESCRIPTION
# Description 

* Use correct platform for the `define-versions-android` action.
* Convert build number to string when defining the build number environment variable in `set-versions-android`.
* Use `tac` instead of `tail -r` when the host machine is Linux based as `tail -r` does not work on Linux based machines.