### PR TITLE
[iOS Versioning] Allow versioning per Target

### DIFF
--- a/lib/fastlane/plugin/fueled/actions/define_versions_ios.rb
+++ b/lib/fastlane/plugin/fueled/actions/define_versions_ios.rb
@@ -15,7 +15,7 @@ module Fastlane
         current_short_version = Helper::FueledHelper.short_version_ios(
           project_path: params[:project_path],
           scheme: params[:scheme]
-          )
+        )
         if current_short_version.split('.').first.to_i >= 1
           UI.important("Not bumping short version as it is higher or equal to 1.0.0")
           Actions.lane_context[SharedValues::SHORT_VERSION_STRING] = current_short_version

--- a/lib/fastlane/plugin/fueled/actions/set_app_versions_plist_ios.rb
+++ b/lib/fastlane/plugin/fueled/actions/set_app_versions_plist_ios.rb
@@ -7,11 +7,13 @@ module Fastlane
         version_string = "#{params[:build_number]}-#{params[:build_config]}"
         other_action.increment_version_number_in_plist(
           version_number: params[:short_version_string],
-            xcodeproj: params[:project_path]
+          xcodeproj: params[:project_path],
+          target: params[:scheme]
         )
         other_action.increment_build_number_in_plist(
           build_number: version_string,
-            xcodeproj: params[:project_path]
+          xcodeproj: params[:project_path],
+          target: params[:scheme]
         )
       end
 
@@ -29,6 +31,13 @@ module Fastlane
             key: :project_path,
             env_name: "PROJECT_PATH",
             description: "The path to the project .xcodeproj",
+            is_string: true,
+            optional: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :scheme,
+            env_name: "SCHEME",
+            description: "The scheme to set the version to",
             is_string: true,
             optional: false
           ),

--- a/lib/fastlane/plugin/fueled/actions/set_app_versions_xcodeproj_ios.rb
+++ b/lib/fastlane/plugin/fueled/actions/set_app_versions_xcodeproj_ios.rb
@@ -7,11 +7,13 @@ module Fastlane
         version_string = "#{params[:build_number]}-#{params[:build_config]}"
         other_action.increment_version_number_in_xcodeproj(
           version_number: params[:short_version_string],
-            xcodeproj: params[:project_path]
+          xcodeproj: params[:project_path],
+          target: params[:scheme]
         )
         other_action.increment_build_number_in_xcodeproj(
           build_number: version_string,
-            xcodeproj: params[:project_path]
+          xcodeproj: params[:project_path],
+          target: params[:scheme]
         )
       end
 
@@ -29,6 +31,13 @@ module Fastlane
             key: :project_path,
             env_name: "PROJECT_PATH",
             description: "The path to the project .xcodeproj",
+            is_string: true,
+            optional: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :scheme,
+            env_name: "SCHEME",
+            description: "The scheme to set the version to",
             is_string: true,
             optional: false
           ),


### PR DESCRIPTION
### Fix
* While integrating fastlane for RRI, it appears they have two targets, that go on the AppStore, with 2 different marketing versions. This ensures we don't override the version set in the other target, as the two apps get build sequentially.

### Note
* Using the `target` option instead of `scheme` as the `scheme` one had no effect 🤷‍♂️ . Targets and Schemes "should" share the same name.