### PR TITLE
[Git-Tag] Use our own tag action instead of fastlane's

### DIFF
--- a/lib/fastlane/plugin/fueled/actions/tag.rb
+++ b/lib/fastlane/plugin/fueled/actions/tag.rb
@@ -12,8 +12,7 @@ module Fastlane
         Actions.lane_context[SharedValues::TAG_NAME] = tag_name
         if other_action.is_ci
           UI.message("Tagging #{tag_name}...")
-          other_action.add_git_tag(tag: tag_name)
-          other_action.push_git_tags(tag: tag_name)
+          other_action.sh("git tag -f \"#{tag_name}\" && git push origin \"refs/tags/#{tag_name}\" --force")
           return tag_name
         else
           UI.message("Not tagging #{tag_name} as we're not on CI.")


### PR DESCRIPTION
### Fix
* Fastlane was always adding a [message to tags](https://github.com/fastlane/fastlane/blob/dac31640214dc976da675e863d0efbd4a99cb526/fastlane/lib/fastlane/actions/add_git_tag.rb#L23) (`-m`) if none was provided, which we do not want. This follows what was previously implemented in the [custom Bitrise step](https://github.com/Fueled/bitrise-custom-steps/blob/c63e803409eb5b3958ce4ef75a99150d4f8888b7/git-tag/step.sh).