### PR TITLE
[Flutter] Add flutter version read and write

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Fueled specific.
 * Android
   - [define_versions_android](#user-content-define_versions_android)
   - [set_app_versions_android](#user-content-set_app_versions_android)
+* Flutter
+  - [define_versions_flutter](#user-content-define_versions_flutter)
+  - [set_app_versions_flutter](#user-content-set_app_versions_flutter)
 
 ## Example
 We use `dotenv` files to specify most of the values being used by the actions. The advantage is that you can have several `dotenv` files, depending on the build target, or even the audience you intend to deliver the build to.
@@ -173,6 +176,17 @@ Your Fastfile should use these values in a next step to set them to the project 
 |-----------------|--------------------|---|
 | `bump_type` <br/> `VERSION_BUMP_TYPE` | The version to bump (`major`, `minor`, `patch`, or `none`) | `none`
 
+#### `define_versions_flutter`
+
+Sets the new version (--build-name) and build number (--build-number) as shared values, without setting them in the pubspec.
+
+This action sets shared values for *build-number* (`SharedValues::FUELED_BUILD_NUMBER`) and *build-name*(`SharedValues::SHORT_VERSION_STRING`).
+Your Fastfile should use these values in a next step to set them to the project accordingly (`set_app_versions_flutter`).
+
+| Key & Env Var | Description | Default Value
+|-----------------|--------------------|---|
+| `bump_type` <br/> `VERSION_BUMP_TYPE` | The version to bump (`major`, `minor`, `patch`, or `none`) | `none`
+
 #### `define_versions_ios`
 
 Sets the new CFBundleVersion and CFBundleShortVersion as shared values, without setting them in the project.
@@ -242,6 +256,15 @@ Update the Android app version using the passed parameters.
 |-----------------|--------------------|---|
 | `short_version_string` | The short version string (eg: 0.2.6) | `SharedValues::SHORT_VERSION_STRING` |
 | `build_number` <br/> `BUILD_NUMBER` | The build number (eg: 625) | `SharedValues::FUELED_BUILD_NUMBER` |
+
+#### `set_app_versions_flutter`
+Update the pubspec.yaml file with the passed short version, build number, and build configuration.
+
+| Key & Env Var | Description | Default Value
+|-----------------|--------------------|---|
+| `build_config` <br/> `BUILD_CONFIGURATION` | The build configuration (eg: Debug) | |
+| `short_version_string` | The short version string (eg: 0.2.6) | `SharedValues::SHORT_VERSION_STRING` |
+| `build_number` | The build number (eg: 625) | `SharedValues::FUELED_BUILD_NUMBER` |
 
 #### `set_app_versions_plist_ios`
 Update the iOS app versions in the plist file (`CFBundleVersion` & `CFShortBundleVersion`) using the passed parameters.

--- a/lib/fastlane/plugin/fueled/actions/define_versions_flutter.rb
+++ b/lib/fastlane/plugin/fueled/actions/define_versions_flutter.rb
@@ -1,0 +1,76 @@
+require_relative '../helper/fueled_helper'
+
+module Fastlane
+  module Actions
+    module SharedValues
+      SHORT_VERSION_STRING = :SHORT_VERSION_STRING
+      FUELED_BUILD_NUMBER = :FUELED_BUILD_NUMBER
+    end
+
+    class DefineVersionsFlutterAction < Action
+      def self.run(params)
+        # Build Number
+        Actions.lane_context[SharedValues::FUELED_BUILD_NUMBER] = Helper::FueledHelper.new_build_number
+        # Short Version
+        current_short_version = Helper::FueledHelper.short_version_flutter
+        if current_short_version.split('.').first.to_i >= 1
+          UI.important("Not bumping short version as it is higher or equal to 1.0.0")
+          Actions.lane_context[SharedValues::SHORT_VERSION_STRING] = current_short_version
+          return
+        end
+        new_version_number = Helper::FueledHelper.bump_semver(
+          semver: current_short_version,
+          bump_type: params[:bump_type]
+        )
+        Actions.lane_context[SharedValues::SHORT_VERSION_STRING] = new_version_number
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Sets the new version (--build-name) and build number (--build-number) as shared values, without setting them in the pubspec."
+      end
+
+      def self.details
+        "
+        This action sets shared values for build-number (SharedValues::FUELED_BUILD_NUMBER) and build-name (SharedValues::SHORT_VERSION_STRING).
+        Your Fastfile should use these values in a next step to set them to the project accordingly (set_app_versions_flutter).
+        "
+      end
+
+      def self.available_options
+        verify_block = lambda do |value|
+          allowed_values = ["major", "minor", "patch", "none"]
+          UI.user_error!("Invalid bump type : #{value}. Allowed values are #{allowed_values.join(', ')}.") unless allowed_values.include?(value)
+        end
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :bump_type,
+            env_name: "VERSION_BUMP_TYPE",
+            description: "The version to bump (major, minor, patch, or none)",
+            optional: false,
+            default_value: "none",
+            verify_block: verify_block
+          )
+        ]
+      end
+
+      def self.output
+        [
+          ['SHORT_VERSION_STRING', 'The short version that should be set'],
+          ['FUELED_BUILD_NUMBER', 'The new build number that should be set']
+        ]
+      end
+
+      def self.authors
+        ["fueled"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/fueled/actions/set_app_versions_flutter.rb
+++ b/lib/fastlane/plugin/fueled/actions/set_app_versions_flutter.rb
@@ -1,0 +1,59 @@
+module Fastlane
+  module Actions
+    module SharedValues
+    end
+
+    class SetAppVersionsFlutterAction < Action
+      def self.run(params)
+        version_string = "#{params[:build_number]}-#{params[:build_config]}"
+        full_version_string = "#{params[:short_version_string]}+#{version_string}"
+        file_name = "pubspec.yaml"
+        text = File.read(file_name)
+        new_contents = text.gsub(/version:\ \d+(\.\d+){0,2}\+[\da-zA-Z]+/, "version: #{full_version_string}")
+        File.open(file_name, "w") { |file| 
+          file.puts new_contents 
+        }
+        UI.important("Updated version in pubspec.yaml to #{full_version_string}")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Update the pubspec.yaml file with the passed short version, build number, and build configuration"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :build_config,
+            env_name: "BUILD_CONFIGURATION",
+            description: "The build configuration (eg: Debug)",
+            optional: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :short_version_string,
+            description: "The short version string (eg: 0.2.6)",
+            optional: true,
+            default_value: Actions.lane_context[SharedValues::SHORT_VERSION_STRING]
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :build_number,
+            description: "The build number (eg: 625)",
+            optional: true,
+            default_value: Actions.lane_context[SharedValues::FUELED_BUILD_NUMBER]
+          )
+        ]
+      end
+
+      def self.authors
+        ["fueled"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
+++ b/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
@@ -42,6 +42,22 @@ module Fastlane
         end
       end
 
+      # Returns the current short version. If the major version in the pubspec
+      # is equal or greater than 1, it will be returned. Otherwise, the version
+      # returned will be the one identified in the last git tag.
+      def self.short_version_flutter
+        file_name = "pubspec.yaml"
+        pubspec_content = File.read(file_name)
+        version = pubspec_content[/version:\ (\d+(\.\d+){0,2})\+[\da-zA-Z]+/m, 1]
+        UI.important("No short version found in the pubspec, will rely on git tags to find out the last short version.") if version.nil?
+        if !version.nil? && version.split('.').first.to_i >= 1
+          version
+        else
+          UI.important("App found in pubspec is lower than 1.0.0 (#{version}), reading the version from the last git tag.")
+          short_version_from_tag
+        end
+      end
+
       # Returns the current short version, only by reading the last tag.
       def self.short_version_from_tag
         last_tag = Actions::LastGitTagAction.run(pattern: nil) || "v0.0.0#0-None"


### PR DESCRIPTION
### Feat
* Add `define_versions` and `set_versions` variants for Flutter projects. They read and write the `pubspec.yaml` file