### PR TITLE
[Action/Necessary] Introduce an action to determine if build is necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Fueled specific.
 * Common
   - [create_github_release](#user-content-create_github_release)
   - [generate_changelog](#user-content-generate_changelog)
+  - [is_build_necessary](#user-content-is_build_necessary)
   - [move_linear_tickets](#user-content-move_linear_tickets)
   - [tag](#user-content-tag)
   - [upload_to_app_center](#user-content-upload_to_app_center)
@@ -249,6 +250,15 @@ Pulls and adds the WWDR Apple Certificate to the given keychain
 |-----------------|--------------------|---|
 | `keychain_name` <br/> `KEYCHAIN_NAME` | The keychain name to install the certificates to | `login` |
 | `keychain_password` <br/> `KEYCHAIN_PASSWORD` | The keychain password to install the certificates to | |
+
+### `is_build_necessary`
+Defines if the build is necessary by looking up changes since the last tag for the same build configuration.<br/>
+If the number of revisions between the last tag matching the given build configuration, and HEAD is higher than 0, the action will return true.
+
+| Key & Env Var | Description | Default Value
+|-----------------|--------------------|---|
+| `build_config` <br/> `BUILD_CONFIGURATION` | The build configuration (eg: Debug) | |
+| `force_necessary` <br/> `FORCE_NECESSARY` | If the lane should continue, regardless of changes being made or not | `false` |
 
 #### `move_linear_tickets`
 Automatically moves Linear tickets form a state to another one, for a specific team and a set of labels (comma separated).

--- a/lib/fastlane/plugin/fueled/actions/is_build_necessary.rb
+++ b/lib/fastlane/plugin/fueled/actions/is_build_necessary.rb
@@ -1,0 +1,81 @@
+require_relative '../helper/fueled_helper'
+
+module Fastlane
+  module Actions
+    module SharedValues
+      IS_BUILD_NECESSARY = :IS_BUILD_NECESSARY
+    end
+
+    class IsBuildNecessaryAction < Action
+      def self.run(params)
+        if params[:force_necessary] || commit_count(build_config: params[:build_config]) > 0
+            UI.important("Build is required.")
+            Actions.lane_context[SharedValues::IS_BUILD_NECESSARY] = true
+            true
+        else
+            UI.important("Build is not required, no additional revisions since last successful build.")
+            Actions.lane_context[SharedValues::IS_BUILD_NECESSARY] = false
+            false
+        end
+      rescue
+        true
+      end
+
+      def self.commit_count(build_config:)
+        last_config_tag = other_action.last_git_tag(pattern: "v*-#{build_config}")
+        sh("git rev-list #{last_config_tag}.. --count").strip.to_i
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Defines if the build is necessary by looking up changes since the last tag for the same build configuration."
+      end
+
+      def self.details
+        "
+        If the number of revisions between the last tag matching the given build configuration, and HEAD
+        is higher than 0, the action will return true.
+        "
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :build_config,
+            env_name: "BUILD_CONFIGURATION",
+            description: "The build configuration (eg: Debug)",
+            optional: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :force_necessary,
+            env_name: "FORCE_NECESSARY",
+            description: "If the lane should continue, regardless of changes being made or not",
+            optional: false,
+            default_value: false
+          )
+        ]
+      end
+
+      def self.return_value
+        "Return if the build is necessary or not"
+      end
+
+      def self.output
+        [
+          ['IS_BUILD_NECESSARY', 'If the build is necessary or not']
+        ]
+      end
+
+      def self.authors
+        ["fueled"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Feat
* Introduce an action to determine if build is necessary. This will help save some build credits for nightly builds on inactive  projects.

### Note
Use it like so : 
```
lane :app_center do
  unless is_build_necessary
    UI.important "Skipping build"
    next
  end
  pre_build
  define_versions_ios
  set_app_versions_xcodeproj_ios
  build
  upload_to_app_center
  tag
  create_github_release
  post_build
end
```