### PR TITLE
[last-git-tag] Implement our own last git tag

### DIFF
--- a/lib/fastlane/plugin/fueled/actions/generate_changelog.rb
+++ b/lib/fastlane/plugin/fueled/actions/generate_changelog.rb
@@ -36,7 +36,7 @@ module Fastlane
       end
 
       def self.run(params)
-        last_config_tag = other_action.last_git_tag(pattern: "v*-#{params[:build_config]}") || ""
+        last_config_tag = Helper::FueledHelper.last_git_tag(build_configuration: params[:build_config]) || ""
         if last_config_tag.empty?
           first_commit = sh("git rev-list --max-parents=0 HEAD | xargs echo -n")
           logs = git_retrieve_commits(first_commit, "HEAD")

--- a/lib/fastlane/plugin/fueled/actions/is_build_necessary.rb
+++ b/lib/fastlane/plugin/fueled/actions/is_build_necessary.rb
@@ -22,7 +22,7 @@ module Fastlane
       end
 
       def self.commit_count(build_config:)
-        last_config_tag = other_action.last_git_tag(pattern: "v*-#{build_config}")
+        last_config_tag = Helper::FueledHelper.last_git_tag(build_configuration: build_config)
         sh("git rev-list #{last_config_tag}.. --count").strip.to_i
       end
 

--- a/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
+++ b/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
@@ -10,7 +10,7 @@ module Fastlane
     class FueledHelper
       # Returns the new build number, by bumping the last git tag build number.
       def self.new_build_number
-        last_tag = Actions::LastGitTagAction.run(pattern: nil) || "v0.0.0#0-None"
+        last_tag = last_git_tag(build_configuration: nil) || "v0.0.0#0-None"
         last_build_number = (last_tag[/#(.*?)-/m, 1] || "0").to_i
         last_build_number + 1
       end
@@ -76,8 +76,19 @@ module Fastlane
 
       # Returns the current short version, only by reading the last tag.
       def self.short_version_from_tag
-        last_tag = Actions::LastGitTagAction.run(pattern: nil) || "v0.0.0#0-None"
+        last_tag = last_git_tag(build_configuration: nil) || "v0.0.0#0-None"
         last_tag[/v(.*?)[(#]/m, 1]
+      end
+
+      def self.last_git_tag(build_configuration:)
+        optional_pattern = build_configuration != nil ? "\'v*-#{build_configuration}\'" : ""
+        command = "git tag --sort=-refname --sort=-creatordate -l #{optional_pattern} | head -n 1"
+        UI.message("#{command}")
+        tag = `#{command}`.chomp
+        UI.message("#{tag}")
+        return tag
+      rescue
+        nil
       end
 
       # Bump a given semver version, by incrementing the appropriate


### PR DESCRIPTION
### Fix
I don't know what happened yet (and if someone has a clue, I'll take it), but with the new year, GH Actions has been tagging past commits with new tag name 🤔 

This resulted in the `fastlane` `last_git_tag` action giving us "older" tags, with a lower build number and version.

<img width="704" alt="Capture d’écran 2022-01-04 à 10 55 02" src="https://user-images.githubusercontent.com/1849419/148041727-314b1181-9931-484b-a65d-915a490ddad6.png">
<img width="442" alt="Capture d’écran 2022-01-04 à 10 56 18" src="https://user-images.githubusercontent.com/1849419/148041733-4ed13510-2862-4466-9bf5-dfac0c1e19ea.png">

In the above example, last_git_tag would wrongly return `v0.5.1#44-Snapshot`

This PR introduces our own `last_git_tag` function in the `Helpers`, which sorts by date, and ref name to mitigate this.