### PR TITLE
feat(appcenter): add option to specify AppCenter owner as environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ P12_PASSWORD=$P12_PASSWORD
 BASE64_CERTIFICATE_INPUT=A_BASE64_ENCODED_P12_FILE
 # Appcenter
 AC_API_TOKEN=$APPCENTER_API_TOKEN
+AC_OWNER_NAME=OwnerName
 AC_APP_NAME=AppName
 AC_DISTRIBUTION_GROUPS="Alpha Release,Collaborators"
 AC_NOTIFY_TESTERS=true
@@ -333,6 +334,7 @@ Note that it only runs on CI.
 | Key & Env Var | Description | Default Value
 |-----------------|--------------------|---|
 | `api_token` <br/> `AC_API_TOKEN` | The API Token to interact with AppCenter APIs | |
+| `owner_name` <br/> `AC_OWNER_NAME` | The owner/organization name in AppCenter | `Fueled` |
 | `app_name` <br/> `AC_APP_NAME` | The app name as set in AppCenter | |
 | `file_path` | The path to the your app file | `Helper::FueledHelper.default_output_file` |
 | `mapping` | The path to the your Android app mapping file | |

--- a/lib/fastlane/plugin/fueled/actions/upload_to_app_center.rb
+++ b/lib/fastlane/plugin/fueled/actions/upload_to_app_center.rb
@@ -11,7 +11,7 @@ module Fastlane
           other_action.appcenter_upload(
             api_token: params[:api_token],
             owner_type: "organization",
-            owner_name: "Fueled",
+            owner_name: params[:owner_name],
             app_name: params[:app_name],
             mapping: params[:mapping],
             dsym: params[:dsym],
@@ -47,6 +47,14 @@ module Fastlane
             key: :api_token,
             env_name: "AC_API_TOKEN",
             description: "The API Token to interact with AppCenter APIs",
+            is_string: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :owner_name,
+            env_name: "AC_OWNER_NAME",
+            description: "The owner/organization name in AppCenter",
+            optional: true,
+            default_value: "Fueled",
             is_string: true
           ),
           FastlaneCore::ConfigItem.new(


### PR DESCRIPTION
**This PR handles following updates**

- The ability to provide AppCenter owner name as an environment variable so that AppCenter builds can be distributed to client's AppCenter accounts as well. I've added a default value as `Fueled` so that existing apps/workflows continue to work.

**Why was this change needed**

- We recently migrated Fennel's codebase to client's repo and AppCenter account but the App Center upload action failed because the plugin has AppCenter owner name hardcoded as `Fueled`. 