### PR TITLE
[Profiles] Only inspect mobileprovision files

### DIFF
--- a/lib/fastlane/plugin/fueled/actions/install_profiles.rb
+++ b/lib/fastlane/plugin/fueled/actions/install_profiles.rb
@@ -9,12 +9,14 @@ module Fastlane
       def self.run(params)
         folder = params[:folder]
         UI.message("Crawling #{folder}...")
-        Dir.children(folder).each do |profile|
-          UI.message("Found #{profile}")
-          other_action.install_provisioning_profile(
-            path: File.join(folder, profile)
-          )
-        end
+        Dir.children(folder)
+          .filter { |f| /mobileprovision$/.match?(f) }
+          .each do |profile|
+            UI.message("Found #{profile}")
+            other_action.install_provisioning_profile(
+              path: File.join(folder, profile)
+            )
+          end
       end
 
       #####################################################


### PR DESCRIPTION
### Fix
Only inspect mobileprovision files. This is needed as the `profiles` folder contains a `.gitignore` file so we can actually add the folder to version control even when it's empty (needed for the project template).