### PR TITLE
[Linear] Consolidate nil and empty checks for linear inputs

### DIFF
--- a/lib/fastlane/plugin/fueled/actions/move_linear_tickets.rb
+++ b/lib/fastlane/plugin/fueled/actions/move_linear_tickets.rb
@@ -10,11 +10,11 @@ module Fastlane
 
     class MoveLinearTicketsAction < Action
       def self.run(params)
-        if params[:from_state] == nil || 
-            params[:to_state] == nil || 
-            params[:labels] == nil || 
-            params[:linear_api_key] == nil ||
-            params[:linear_team_id] == nil
+        if Helper::FueledHelper.nil_or_empty(params[:from_state]) || 
+          Helper::FueledHelper.nil_or_empty(params[:to_state]) || 
+          Helper::FueledHelper.nil_or_empty(params[:labels]) || 
+          Helper::FueledHelper.nil_or_empty(params[:linear_api_key]) ||
+          Helper::FueledHelper.nil_or_empty(params[:linear_team_id])
             UI.important("Not updating Linear tickets because of missing parameters.")
             return
         end

--- a/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
+++ b/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
@@ -8,6 +8,11 @@ module Fastlane
 
   module Helper
     class FueledHelper
+      # Returns if a string is nil or empty.
+      def self.nil_or_empty(input)
+        input.nil? || input.empty?
+      end
+      
       # Returns the new build number, by bumping the last git tag build number.
       def self.new_build_number
         last_tag = Actions::LastGitTagAction.run(pattern: nil) || "v0.0.0#0-None"


### PR DESCRIPTION
### Fix
* Consolidate nil and empty checks for linear inputs. Having the values as `VALUE=` in the env file passes an empty value, and not a nil one. This PR adds the empty check in addition to the nil check.