### PR TITLE
feat(flutter): add actions to replace flutter scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Fueled specific.
 * Flutter
   - [define_versions_flutter](#user-content-define_versions_flutter)
   - [set_app_versions_flutter](#user-content-set_app_versions_flutter)
+  - [formatting_checks_flutter](#user-content-formatting_checks_flutter)
+  - [generate_files_flutter](#user-content-generate_files_flutter)
+  - [ci_checks_flutter](#user-content-ci_checks_flutter)
 * React Native
   - [define_versions_react_native](#user-content-define_versions_react_native)
 
@@ -72,7 +75,7 @@ TESTFLIGHT_USERNAME=$APPLE_ID
 TESTFLIGHT_APP_SPECIFIC_PASSWORD=$APPLE_APP_PASSWORD
 ```
 
-Here is a sample iOS Fastfile leveraging this plugin. 
+Here is a sample iOS Fastfile leveraging this plugin.
 
 ```
 fastlane_version "2.197.0"
@@ -111,7 +114,7 @@ platform :ios do
       scheme: ENV['SCHEME']
     )
   end
-  
+
   private_lane :pre_build do
     create_keychain(
       name: keychain_name,
@@ -354,6 +357,23 @@ Note that it only runs on CI.
 | `username` <br/> `TESTFLIGHT_USERNAME` | The app name as set in AppCenter | |
 | `password` <br/> `TESTFLIGHT_APP_SPECIFIC_PASSWORD` | The AppleId app specific password | |
 | `target_platform` | The target platform (`macos` | `ios` | `appletvos`) | `ios` |
+
+
+#### `formatting_checks_flutter`
+Check the formatting of the code using `flutter format`
+
+
+#### `generate_files_flutter`
+Performs code generation
+
+| Key & Env Var | Description | Default Value
+|-----------------|--------------------|---|
+| `build_variant` | The build variant used for generating files | `debug` |
+
+
+#### `ci_checks_flutter`
+Run tests and check code coverage
+
 
 ## Issues and Feedback
 

--- a/lib/fastlane/plugin/fueled/actions/ci_checks_flutter.rb
+++ b/lib/fastlane/plugin/fueled/actions/ci_checks_flutter.rb
@@ -1,0 +1,38 @@
+module Fastlane
+  module Actions
+    module SharedValues
+    end
+
+    class CiChecksFlutterAction < Action
+      def self.run(params)
+        UI.message("Running Lint checks")
+        sh("flutter analyze")
+        UI.message("Running code coverage fix")
+        sh("./scripts/code_coverage_helper.sh") #TODO: incorporate the code from `code_coverage_helper.sh` into this action once this issue has been resolved https://github.com/flutter/flutter/issues/27997
+        UI.message("Running unit tests")
+        sh("rm -rf coverage")
+        sh("flutter test --coverage")
+        sh("genhtml -o coverage coverage/lcov.info")
+        sh("flutter test test/essentials.dart")
+        UI.message("Running integration tests")
+        sh("flutter test integration_test")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Run tests and check code coverage"
+      end
+
+      def self.authors
+        ["fueled"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/fueled/actions/formatting_checks_flutter.rb
+++ b/lib/fastlane/plugin/fueled/actions/formatting_checks_flutter.rb
@@ -1,0 +1,30 @@
+module Fastlane
+  module Actions
+    module SharedValues
+    end
+
+    class FormattingChecksFlutterAction < Action
+      def self.run(params)
+        UI.message("Checking formatting")
+        sh("flutter pub get")
+        sh("flutter format -o none --set-exit-if-changed .")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Check formatting for a Flutter project"
+      end
+
+      def self.authors
+        ["fueled"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/fueled/actions/generate_files_flutter.rb
+++ b/lib/fastlane/plugin/fueled/actions/generate_files_flutter.rb
@@ -1,0 +1,45 @@
+module Fastlane
+  module Actions
+    module SharedValues
+    end
+
+    class GenerateFilesFlutterAction < Action
+      def self.run(params)
+        variant = params[:build_variant]
+        UI.message("Running Codegen for #{variant}")
+        sh("flutter pub run build_runner build --delete-conflicting-outputs --define \"dynamic_config_generator|config_builder=variant=#{variant}\"")
+        UI.message("Generating Localization files")
+        sh("flutter pub run easy_localization:generate -S \"assets/translations\" -O \"lib/gen\"")
+        sh("flutter pub run easy_localization:generate -S \"assets/translations\" -O \"lib/gen\" -o \"locale_keys.g.dart\" -f keys")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Run code generators for a Flutter project"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :build_variant,
+            env_name: "BUILD_VARIANT",
+            description: "The build variant used for generating config file",
+            is_string: true,
+            default_value: "debug"
+          )
+        ]
+      end
+
+      def self.authors
+        ["fueled"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a few Flutter actions which were earlier being accomplished using scripts in the Flutter template. It's companion PR can be found [here](https://github.com/Fueled/project-template-flutter/pull/32) which removes the scripts from the Flutter template.