### PR TITLE
fix(*): get dependencies before generating files

### DIFF
--- a/lib/fastlane/plugin/fueled/actions/generate_files_flutter.rb
+++ b/lib/fastlane/plugin/fueled/actions/generate_files_flutter.rb
@@ -7,6 +7,7 @@ module Fastlane
       def self.run(params)
         variant = params[:build_variant]
         UI.message("Running Codegen for #{variant}")
+        sh("flutter pub get")
         sh("flutter pub run build_runner build --delete-conflicting-outputs --define \"dynamic_config_generator|config_builder=variant=#{variant}\"")
         UI.message("Generating Localization files")
         sh("flutter pub run easy_localization:generate -S \"assets/translations\" -O \"lib/gen\"")


### PR DESCRIPTION
The [nightly build for the template](https://github.com/Fueled/project-template-flutter/runs/5555923074?check_suite_focus=true) has been failing since I removed scripts from it. The issue is that in case of PR check, `flutter pub get` is called by the `formatting_checks_flutter` action. However, in case of nightly builds, that action isn't invoked and as such, the dependencies aren't fetched.

This PR fixes the issue by introducing a `flutter pub get` command in the `generate_files_flutter` action.