### PR TITLE
fix short_version_from_tag

### DIFF
--- a/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
+++ b/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
@@ -98,7 +98,7 @@ module Fastlane
       # Returns the current short version, only by reading the last tag.
       def self.short_version_from_tag(filter:)
         last_tag = fetch_last_tag(filter: filter)
-        last_tag = last_tag || "v0.0.0#0-None"
+        last_tag = (last_tag.nil? || last_tag.empty?) ?  "v0.0.0#0-None" : last_tag
         last_tag[/v(.*?)[(#]/m, 1]
       end
 


### PR DESCRIPTION
adds additional check to the return value of fetch_last_tag when it is empty string instead of nil