### PR TITLE
chore(appcenter): update appcenter to support ruby 3.x

### DIFF
--- a/fastlane-plugin-fueled.gemspec
+++ b/fastlane-plugin-fueled.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.5'
 
-  spec.add_dependency('fastlane-plugin-appcenter', '~> 1.11.0')
+  spec.add_dependency('fastlane-plugin-appcenter', '~> 2.0.0')
   spec.add_dependency('fastlane-plugin-versioning', '~> 0.5.0')
 
   spec.add_development_dependency('bundler')


### PR DESCRIPTION
- This appcenter version is ruby 3 compatible, older one was throwing[ this issue
](https://github.com/microsoft/fastlane-plugin-appcenter/issues/279) and the fix is in the [new version](https://github.com/microsoft/appcenter/issues/2357)