### PR TITLE
Ignore iOS short_version value when first character is a non-digit

### DIFF
--- a/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
+++ b/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
@@ -46,6 +46,10 @@ module Fastlane
           scheme: scheme,
           build_configuration_name: nil
         )
+        if !version.split('.').first.match?(/[[:digit:]]/)
+          UI.important("Version found in plist is not digit: #{version}")
+          version = nil
+        end
         UI.important("No short version found in plist, looking in Xcodeproj...") if version.nil?
         if version.nil?
           version = Actions::GetVersionNumberFromXcodeprojAction.run(
@@ -57,6 +61,7 @@ module Fastlane
         end
         UI.important("No short version found in the project, will rely on git tags to find out the last short version.") if version.nil?
         if !skip_version_limit && !version.nil? && version.split('.').first.to_i >= 1
+          UI.important("Version: #{version}")
           version
         else
           short_version_from_tag(filter:build_type)
@@ -97,6 +102,7 @@ module Fastlane
 
       # Returns the current short version, only by reading the last tag.
       def self.short_version_from_tag(filter:)
+        UI.important("Setting short_version from most recent tag")
         last_tag = fetch_last_tag(filter: filter)
         last_tag = (last_tag.nil? || last_tag.empty?) ?  "v0.0.0#0-None" : last_tag
         last_tag[/v(.*?)[(#]/m, 1]


### PR DESCRIPTION
Yesterday Immi pushed a release with tags `1.0.4` while our main `develop` branch remained `1.0.3`
I noticed our nightly snapshot was pushed with tags `1.0.4`, and found that the version is being set by recent tags, and not plist or xcodeproj as expected.

This PR ignores any version whose first character is not a digit, as well as provide some additional logs for debugging.

As you can see here, our plist version is `$(MARKETING_VERSION)`; and while this technically isn't `nil`, maybe it should be regarded as such to avoid falling back on tags. This way, setting to `nil` allows the value to be set via Xcodeproj. 

![Screen Shot 2022-05-24 at 5 41 57 PM](https://user-images.githubusercontent.com/4371660/170137644-f7b055f5-3f78-4712-bdb8-81490082b8ce.png)

Please feel free to propose a more elegant solution as I am not a Ruby dev by training 🙂 