### PR TITLE
feat(*): add the ability to skip integration tests on flutter

### DIFF
--- a/lib/fastlane/plugin/fueled/actions/ci_checks_flutter.rb
+++ b/lib/fastlane/plugin/fueled/actions/ci_checks_flutter.rb
@@ -14,8 +14,10 @@ module Fastlane
         sh("flutter test --coverage")
         sh("genhtml -o coverage coverage/lcov.info")
         sh("flutter test test/essentials.dart")
-        UI.message("Running integration tests")
-        sh("flutter test integration_test")
+        if !params[:skip_integration_tests]
+          UI.message("Running integration tests")
+          sh("flutter test integration_test")
+        end
       end
 
       #####################################################
@@ -25,6 +27,20 @@ module Fastlane
       def self.description
         "Run tests and check code coverage"
       end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :skip_integration_tests,
+            env_name: "SKIP_INTEGRATION_TESTS",
+            description: "If true, only unit tests are executed",
+            optional: true,
+            is_string: false,
+            default_value: false
+          )
+        ]
+      end
+
 
       def self.authors
         ["fueled"]


### PR DESCRIPTION
[Sometimes](https://github.com/Fueled/five-resorts-flutter/runs/6775662604?check_suite_focus=true#step:20:539), projects do not have any integration tests and hence, the `ci_checks_flutter` action fails. This PR makes running the integration tests optional.