### PR TITLE
[iOS] Make sure version is not nil before splitting it

### DIFF
--- a/lib/fastlane/plugin/fueled/actions/define_versions_ios.rb
+++ b/lib/fastlane/plugin/fueled/actions/define_versions_ios.rb
@@ -10,7 +10,7 @@ module Fastlane
     class DefineVersionsIosAction < Action
       def self.run(params)
         # Build Number
-        Actions.lane_context[SharedValues::FUELED_BUILD_NUMBER] = Helper::FueledHelper.new_build_number(filter:params[:build_type])
+        Actions.lane_context[SharedValues::FUELED_BUILD_NUMBER] = Helper::FueledHelper.new_build_number(filter: '')
         # Short Version
         current_short_version = Helper::FueledHelper.short_version_ios(
           project_path: params[:project_path],

--- a/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
+++ b/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
@@ -46,7 +46,7 @@ module Fastlane
           scheme: scheme,
           build_configuration_name: nil
         )
-        if !version.split('.').first.match?(/[[:digit:]]/)
+        if version != nil && !version.split('.').first.match?(/[[:digit:]]/)
           UI.important("Version found in plist is not digit: #{version}")
           version = nil
         end


### PR DESCRIPTION
### Description
Make sure version is not `nil` before splitting it
Also pull version number regardless of the build configuration

### Affects
- iOS