### PR TITLE
[iOS][ShortVersion] Pull short version per build type

### DIFF
--- a/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
+++ b/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
@@ -44,7 +44,7 @@ module Fastlane
           xcodeproj: project_path,
           target: nil,
           scheme: scheme,
-          build_configuration_name: nil
+          build_configuration_name: build_type
         )
         if version != nil && !version.split('.').first.match?(/[[:digit:]]/)
           UI.important("Version found in plist is not digit: #{version}")
@@ -56,7 +56,7 @@ module Fastlane
             xcodeproj: project_path,
             target: nil,
             scheme: scheme,
-            build_configuration_name: nil
+            build_configuration_name: build_type
           )
         end
         UI.important("No short version found in the project, will rely on git tags to find out the last short version.") if version.nil?


### PR DESCRIPTION
## Description
Pull short version per build type

## Helpful Instructions
This is needed as in some circumstances, the *Marketing Version* (or Short Version) will be different per build configuration.