### PR TITLE
feat(secrets): add action to generate ArkanaKeys package

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Fueled specific.
 * iOS
     - [define_versions_ios](#user-content-define_versions_ios)
     - [import_base_64_certificates](#user-content-import_base64_certificates)
+    - [generate_secrets_ios](#generate_secrets_ios)
     - [install_profiles](#user-content-install_profiles)
     - [install_wwdr_certificate](#user-content-install_wwdr_certificate)
     - [set_app_versions_plist_ios](#user-content-set_app_versions_plist_ios)
@@ -256,6 +257,17 @@ Changelog is made of commits between now, and the previous tag using the same bu
 |-----------------|-----------------------------------------------------------------|---|
 | `build_config` <br/> `BUILD_CONFIGURATION` | The build configuration (eg: Debug)                             | `Debug` |
 | `ticket_base_url` <br/> `TICKET_BASE_URL` | The base url for tickets (eg. https://linear.app/fueled/issue/) | `https://linear.app/fueled/issue/` |
+
+#### `generate_secrets_ios`
+
+Generate [ArkanaKeys](https://github.com/rogerluan/arkana) Package containing project secrets.
+
+The generated package contains secrets based on the provided template and environment file. 
+
+| Key & Env Var | Description                                                     | Default Value
+|-----------------|-----------------------------------------------------------------|---|
+| `template_file` <br/> `ARKANA_TEMPLATE_FILE` | Name/Path of Arkana template file                             | `.arkana.yml` |
+| `environment_file` <br/> `ARKANA_ENVIRONMENT_FILE` | Name/Path of Arkana environment file | `.env.arkana_ci` |
 
 #### `import_base64_certificates`
 

--- a/lib/fastlane/plugin/fueled/actions/generate_secrets_ios.rb
+++ b/lib/fastlane/plugin/fueled/actions/generate_secrets_ios.rb
@@ -1,0 +1,51 @@
+module Fastlane
+    module Actions
+      module SharedValues
+      end
+  
+      class GenerateSecretsIosAction < Action
+        def self.run(params)
+          template_file = params[:template_file]
+          environment_file = params[:environment_file]
+          UI.message("Generating ArkanaKeys Package")
+          sh("bundle exec arkana -c #{template_file} -e #{environment_file}")
+        end
+  
+        #####################################################
+        # @!group Documentation
+        #####################################################
+  
+        def self.description
+          "Generate ArkanaKeys Package with project secrets"
+        end
+  
+        def self.available_options
+          [
+            FastlaneCore::ConfigItem.new(
+              key: :template_file,
+              env_name: "ARKANA_TEMPLATE_FILE",
+              description: "The template file used to generate the Arkana Keys Package",
+              is_string: true,
+              default_value: ".arkana.yml"
+            ),
+            FastlaneCore::ConfigItem.new(
+              key: :environment_file,
+              env_name: "ARKANA_ENVIRONMENT_FILE",
+              description: "The environment file containing the secrets",
+              is_string: true,
+              default_value: ".env.arkana_ci"
+            )
+          ]
+        end
+  
+        def self.authors
+          ["fueled"]
+        end
+  
+        def self.is_supported?(platform)
+            [:ios, :mac].include?(platform)
+        end
+      end
+    end
+  end
+  


### PR DESCRIPTION
**This PR includes following updates**

- Adds a new action that lets you generate the ArkanaKeys package that is part of Fueled iOS Template to manage project keys and secrets. 