### PR TITLE
Add git credential store action

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Fueled specific.
     - [generate_changelog](#user-content-generate_changelog)
     - [is_build_necessary](#user-content-is_build_necessary)
     - [move_linear_tickets](#user-content-move_linear_tickets)
+    - [use_git_credential_store](#user-content-use_git_credential_store)
     - [tag](#user-content-tag)
     - [upload_to_app_center](#user-content-upload_to_app_center)
 * iOS
@@ -34,7 +35,7 @@ Fueled specific.
     - [install_wwdr_certificate](#user-content-install_wwdr_certificate)
     - [set_app_versions_plist_ios](#user-content-set_app_versions_plist_ios)
     - [set_app_versions_xcodeproj_ios](#user-content-set_app_versions_xcodeproj_ios)
-    - [check_code_coverage_ios](#check_code_coverage_ios)
+    - [check_code_coverage_ios](#user-content-check_code_coverage_ios)
     - [upload_to_app_store](#user-content-upload_to_app_store)
 * Android
     - [define_versions_android](#user-content-define_versions_android)
@@ -380,6 +381,16 @@ Check how much of your code is covered by unit tests.
 | `code_coverage_config_file_path` | The path of the code coverage config file, the structure of this file is created by Fueled |  |
 | `result_bundle_file_path` | The result bundle file path (xcresult) | |
 | `minimum_code_coverage_percentage` | The minimum code coverage percentage accepted (eg: 64.5) | 80 |
+
+#### `use_git_credential_store`
+
+Store your git credential in the git credential store (~/.git-credentials)
+
+| Key & Env Var | Description | Default Value
+|-----------------|--------------------|---|
+| `git_token` <br/> `GIT_TOKEN` | The git token that will be stored | |
+| `git_user_name` <br/> `GIT_USER_NAME` | The git username that will be stored | |
+| `git_host` <br/> `GIT_HOST` | The host of your git repository | |
 
 #### `tag`
 

--- a/lib/fastlane/plugin/fueled/actions/use_git_credential_store.rb
+++ b/lib/fastlane/plugin/fueled/actions/use_git_credential_store.rb
@@ -1,0 +1,69 @@
+module Fastlane
+    module Actions
+
+        class UseGitCredentialStoreAction < Action
+        
+            def self.run(params)
+                commands = <<~BASH
+                git config --global credential.helper store
+
+                git credential-store --file ~/.git-credentials store << EOF
+                protocol=https
+                host=#{params[:git_host]}
+                username=#{params[:git_user_name]}
+                password=#{params[:git_token]}
+              BASH
+              
+              if system(commands)
+                UI.success("Your git credentials are saved to the git credential store ✅.")
+              else
+                UI.user_error!("Something went wrong, your git credentials are not saved. 🚫")
+              end
+            end
+        
+        #####################################################
+        # @!group Documentation
+        #####################################################
+  
+        def self.description
+            "Employ Git's credential storage to securely save the Git username and password/token, eliminating the need to specify them repeatedly with each Git command."
+        end
+
+        def self.available_options
+            [
+              FastlaneCore::ConfigItem.new(
+                key: :git_token,
+                env_name: "GIT_TOKEN",
+                description: "The git token that will be added to the git credential store",
+                is_string: true,
+                optional: false
+              ),
+              FastlaneCore::ConfigItem.new(
+                key: :git_user_name,
+                env_name: "GIT_USER_NAME",
+                description: "The git username that will be added to the git credential store",
+                is_string: true,
+                optional: true,
+                default_value: "Fueled"
+              ),
+              FastlaneCore::ConfigItem.new(
+                key: :git_host,
+                env_name: "GIT_HOST",
+                description: "The host of your git repository (e.g. github.com, bitbucket.com, or gitlab.com)",
+                is_string: true,
+                optional: true,
+                default_value: "github.com"
+              )
+            ]
+          end
+    
+          def self.authors
+            ["fueled"]
+          end
+    
+          def self.is_supported?(platform)
+              true
+          end
+    end
+  end
+end


### PR DESCRIPTION
If you need to perform Git commands such as pushing a tag or creating a release on GitHub, you'll require write access to the repository. When using GitHub Actions, you can use the `GITHUB_TOKEN` for authorization.

 However, with an external CI/CD provider like Codemagic, you may need to specify the token and username with each Git command or store the credentials using Git Credential Store. The new action simplifies this process.