### PR TITLE
fix(*): fix flutter versioning

### DIFF
--- a/lib/fastlane/plugin/fueled/actions/set_app_versions_flutter.rb
+++ b/lib/fastlane/plugin/fueled/actions/set_app_versions_flutter.rb
@@ -5,8 +5,7 @@ module Fastlane
 
     class SetAppVersionsFlutterAction < Action
       def self.run(params)
-        version_string = "#{params[:build_number]}-#{params[:build_config]}"
-        full_version_string = "#{params[:short_version_string]}+#{version_string}"
+        full_version_string = "#{params[:short_version_string]}-#{params[:build_config]}+#{params[:build_number]}"
         file_name = "pubspec.yaml"
         text = File.read(file_name)
         new_contents = text.gsub(/version:\ \d+(\.\d+){0,2}\+[\da-zA-Z\-]+/, "version: #{full_version_string}")


### PR DESCRIPTION
<img width="695" alt="image" src="https://user-images.githubusercontent.com/16430299/233614261-9a3b21ab-fce7-4f4d-8f08-7027140cbca8.png">

`1.0.0+19-Release` - this is how the version is being set currently. However, if you look at the image above, you can see that the part after `+` is supposed to be the build number. This results in the builds not having the release / snapshot suffix.

[Android Builds](https://appcenter.ms/orgs/Fueled/apps/Alpas-1/distribute/releases)
[iOS Builds](https://appcenter.ms/orgs/Fueled/apps/Alpas/distribute/releases)
[Flutter Builds](https://appcenter.ms/orgs/Fueled/apps/Meow-Wolf-Android/distribute/releases)

This PR aims to fix that by adding the build type parameter to the version name instead of version code