### PR TITLE
Upload all available assets when creating GitHub release

### DIFF
--- a/lib/fastlane/plugin/fueled/actions/create_github_release.rb
+++ b/lib/fastlane/plugin/fueled/actions/create_github_release.rb
@@ -16,7 +16,7 @@ module Fastlane
             name: release_name,
             tag_name: tag_name,
             description: Actions.lane_context[SharedValues::CHANGELOG_GITHUB],
-            upload_assets: [params[:upload_assets]]
+            upload_assets: params[:upload_assets]
           )
         else
           UI.message("Not creating a GH release as we're not on CI.")
@@ -73,7 +73,8 @@ module Fastlane
             env_name: "UPLOAD_ASSETS",
             description: "Assets to be included with the release",
             optional: false,
-            default_value: Helper::FueledHelper.default_output_file
+            type: Array,
+            default_value: Helper::FueledHelper.default_gh_release_output_files
           )
         ]
       end

--- a/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
+++ b/lib/fastlane/plugin/fueled/helper/fueled_helper.rb
@@ -131,8 +131,7 @@ module Fastlane
       end
 
       # Returns the default artefact file depending on the platform (ios vs android).
-      # This function is being used by the upload_to_app_center and the
-      # create_github_release actions.
+      # This function is being used by the upload_to_app_center
       def self.default_output_file
         platform = Actions.lane_context[Actions::SharedValues::PLATFORM_NAME].to_s
         if platform == "ios"
@@ -143,6 +142,19 @@ module Fastlane
           Actions.lane_context[Actions::SharedValues::GRADLE_AAB_OUTPUT_PATH]
         end
       end
+
+      # Returns the list of generated build artifacts.
+      # This function is being used by the create_github_release actions.
+      def self.default_gh_release_output_files
+        [
+          Actions.lane_context[Actions::SharedValues::IPA_OUTPUT_PATH],
+          Actions.lane_context[Actions::SharedValues::DSYM_OUTPUT_PATH],
+          Actions.lane_context[Actions::SharedValues::GRADLE_APK_OUTPUT_PATH],
+          Actions.lane_context[Actions::SharedValues::GRADLE_AAB_OUTPUT_PATH],
+          Actions.lane_context[Actions::SharedValues::GRADLE_MAPPING_TXT_OUTPUT_PATH]
+        ].compact!
+      end
+
     end
   end
 end


### PR DESCRIPTION
# Description

Adds support for multiplatform projects where both iOS and Android assets are produced, by trying to upload all produced assets.