### PR TITLE
Update define version default build type to none

### DIFF
--- a/lib/fastlane/plugin/fueled/actions/define_versions_android.rb
+++ b/lib/fastlane/plugin/fueled/actions/define_versions_android.rb
@@ -64,9 +64,10 @@ module Fastlane
           ),
           FastlaneCore::ConfigItem.new(
             key: :build_type,
-            env_name: "BUILD_CONFIGURATION",
+            env_name: "BUILD_TYPE_FILTER",
             description: "This is used to retrieve tag belonging to this build_type",
-            optional: true,
+            optional: false,
+            default_value: ""
           )
         ]
       end

--- a/lib/fastlane/plugin/fueled/actions/define_versions_flutter.rb
+++ b/lib/fastlane/plugin/fueled/actions/define_versions_flutter.rb
@@ -63,10 +63,11 @@ module Fastlane
             default_value: false
           ),
           FastlaneCore::ConfigItem.new(
-             key: :build_type,
-             env_name: "BUILD_CONFIGURATION",
-             description: "This is used to retrieve tag belonging to this build_type",
-             optional: true,
+            key: :build_type,
+            env_name: "BUILD_TYPE_FILTER",
+            description: "This is used to retrieve tag belonging to this build_type",
+            optional: false,
+            default_value: ""
           )
         ]
       end

--- a/lib/fastlane/plugin/fueled/actions/define_versions_ios.rb
+++ b/lib/fastlane/plugin/fueled/actions/define_versions_ios.rb
@@ -83,9 +83,10 @@ module Fastlane
           ),
           FastlaneCore::ConfigItem.new(
             key: :build_type,
-            env_name: "BUILD_CONFIGURATION",
+            env_name: "BUILD_TYPE_FILTER",
             description: "This is used to retrieve tag belonging to this build_type",
-            optional: true,
+            optional: false,
+            default_value: ""
           )
         ]
       end

--- a/lib/fastlane/plugin/fueled/actions/define_versions_react_native.rb
+++ b/lib/fastlane/plugin/fueled/actions/define_versions_react_native.rb
@@ -57,20 +57,21 @@ module Fastlane
             default_value: "none",
             verify_block: verify_block
           ),
-         FastlaneCore::ConfigItem.new(
-           key: :disable_version_limit,
-           env_name: "DISABLE_VERSION_LIMIT",
-           description: "When true it skips the version limiting currently set for (1.x.x)+ versions",
-           optional: true,
-           is_string: false,
-           default_value: false
-         ),
-         FastlaneCore::ConfigItem.new(
-            key: :build_type,
-            env_name: "BUILD_CONFIGURATION",
-            description: "This is used to retrieve tag belonging to this build_type",
+          FastlaneCore::ConfigItem.new(
+            key: :disable_version_limit,
+            env_name: "DISABLE_VERSION_LIMIT",
+            description: "When true it skips the version limiting currently set for (1.x.x)+ versions",
             optional: true,
-         )
+            is_string: false,
+            default_value: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :build_type,
+            env_name: "BUILD_TYPE_FILTER",
+            description: "This is used to retrieve tag belonging to this build_type",
+            optional: false,
+            default_value: ""
+          )
         ]
       end
 


### PR DESCRIPTION
# Description

Change the default behavior of `define_versions_*` to use the latest tag regardless of the build type when incrementing the build version, while still allowing `build_type` to be passed as an argument if independent build type versioning is required.