### PR TITLE
Generate code coverage reports action (iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Fueled specific.
     - [set_app_versions_plist_ios](#user-content-set_app_versions_plist_ios)
     - [set_app_versions_xcodeproj_ios](#user-content-set_app_versions_xcodeproj_ios)
     - [check_code_coverage_ios](#user-content-check_code_coverage_ios)
+    - [generate_code_coverage_reports_ios](#user-content-generate_code_coverage_reports_ios)
     - [upload_to_app_store](#user-content-upload_to_app_store)
 * Android
     - [define_versions_android](#user-content-define_versions_android)
@@ -383,6 +384,17 @@ Check how much of your code is covered by unit tests.
 | `code_coverage_config_file_path` | The path of the code coverage config file, the structure of this file is created by Fueled |  |
 | `result_bundle_file_path` | The result bundle file path (xcresult) | |
 | `minimum_code_coverage_percentage` | The minimum code coverage percentage accepted (eg: 64.5) | 80 |
+
+### `generate_code_coverage_reports_ios`
+
+Generate code coverage reports and return the path of the generated file.
+
+| Key & Env Var | Description | Default Value
+|-----------------|--------------------|---|
+| `code_coverage_config_file_path` | The path of the code coverage config file, the structure of this file is created by Fueled |  |
+| `result_bundle_file_path` | The result bundle file path (xcresult) | |
+| `minimum_code_coverage_percentage` | The minimum code coverage percentage accepted (eg: 64.5) | 80 |
+
 
 #### `use_git_credential_store`
 

--- a/lib/fastlane/plugin/fueled/actions/generate_code_coverage_reports_ios.rb
+++ b/lib/fastlane/plugin/fueled/actions/generate_code_coverage_reports_ios.rb
@@ -3,7 +3,7 @@ require_relative '../helper/fueled_helper'
 module Fastlane
     module Actions
 
-    class CheckCodeCoverageIosAction < Action
+    class GenerateCodeCoverageReportsIosAction < Action
 
         def self.run(params)
             code_coverage_config_file_path = params[:code_coverage_config_file_path]
@@ -14,13 +14,22 @@ module Fastlane
               UI.user_error!("Minimum code coverage percentage should be between 0 and 100.")
             end 
 
-            total_code_coverage_percentage = Helper::FueledHelper.calculate_code_coverage_percentage(code_coverage_config_file_path, result_bundle_file_path)
+            report_file_string = Helper::FueledHelper.calculate_code_coverage_percentage(
+              code_coverage_config_file_path,
+              result_bundle_file_path,
+              minimum_code_coverage_percentage,
+              true
+            )
             
-            if total_code_coverage_percentage < minimum_code_coverage_percentage
-              UI.build_failure!("Code coverage percentage is below the minimum! 🚫🚫🚫")
-            else
-              UI.success("Code coverage percentage is accepted ✅.")
+            current_datetime = DateTime.now.strftime('%Y%m%d%H%M%S')
+            file_name = "./test_coverage_report_#{current_datetime}.html"
+
+            File.open(File.expand_path(file_name), "w") do |file|
+              file.write(report_file_string)
             end
+
+            UI.success("Code coverage reports have been generated successfully ✅.")
+            file_name
         end
 
          #####################################################
@@ -28,7 +37,7 @@ module Fastlane
         #####################################################
   
         def self.description
-            "Check the code coverage percentage, if it's lower than the provided one the action will fail. result_bundle should be set to true in your scan action"
+            "Generate code coverage reports"
         end
 
         def self.available_options


### PR DESCRIPTION
Each project can have a different place to store these generated reports, we can push them to the repo using the default branch, but some projects don't allow direct push to the default branch, and instead, we should open PRs.

Also, some projects may need to store these reports outside the source code.

So it depends. This action will generate an HTML file for the code coverage and returns the generated file path.

![Screenshot 2023-06-01 at 2 56 53 PM](https://github.com/Fueled/fastlane-plugin-fueled/assets/19314956/5ee1113b-8044-4480-9a64-b61f1440c12e)

UI updates:

![Screenshot 2023-06-02 at 12 18 05 PM](https://github.com/Fueled/fastlane-plugin-fueled/assets/19314956/792a890b-c6de-4aa6-9414-b7003f577d35)
