### PR TITLE
feat(testfairy): add testfairy support to fastlane

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ Fueled specific.
     - [check_code_coverage_ios](#user-content-check_code_coverage_ios)
     - [generate_code_coverage_reports_ios](#user-content-generate_code_coverage_reports_ios)
     - [upload_to_app_store](#user-content-upload_to_app_store)
+    - [upload_to_test_fairy_ios](#user-content-upload_to_test_fairy_ios)
 * Android
     - [define_versions_android](#user-content-define_versions_android)
     - [set_app_versions_android](#user-content-set_app_versions_android)
+    - [upload_to_test_fairy_android](#user-content-upload_to_test_fairy_android)
 * Flutter
     - [define_versions_flutter](#user-content-define_versions_flutter)
     - [set_app_versions_flutter](#user-content-set_app_versions_flutter)
@@ -446,6 +448,18 @@ This action uses an application specific password. Note that it only runs on CI.
 | `username` <br/> `TESTFLIGHT_USERNAME` | The app name as set in AppCenter | |
 | `password` <br/> `TESTFLIGHT_APP_SPECIFIC_PASSWORD` | The AppleId app specific password | |
 | `target_platform` | The target platform (`macos` | `ios` | `appletvos`) | `ios` |
+
+#### `upload_to_test_fairy_ios`
+#### `upload_to_test_fairy_android`
+
+Upload the given file to TestFairy. This action uses an API Key. Note that it only runs on CI.
+
+| Key & Env Var | Description | Default Value
+|-----------------|--------------------|---|
+| `api_key` | The upload API token to interact with<br/>TestFairy APIs | |
+| `ipa` (iOS) <br/> `apk` (Android) | The path to the your app file | |
+| `comment` <br/> | The changelog for this release | `Actions.lane_context[`<br/>&nbsp;&nbsp;&nbsp;&nbsp;`SharedValues::CHANGELOG_MARKDOWN_PUBLIC]` |
+| `dsym` (iOS) <br/> `mapping` (Android) | The path to your IPA dsym/APK mapping file | |
 
 #### `formatting_checks_flutter`
 

--- a/lib/fastlane/plugin/fueled/actions/upload_to_test_fairy_android.rb
+++ b/lib/fastlane/plugin/fueled/actions/upload_to_test_fairy_android.rb
@@ -1,0 +1,75 @@
+require_relative '../helper/fueled_helper'
+
+module Fastlane
+  module Actions
+    module SharedValues
+    end
+
+    class UploadToTestFairyAndroidAction < Action
+      def self.run(params)
+        if other_action.is_ci
+          other_action.testfairy(
+            api_key: params[:api_key],
+            apk: params[:apk],
+            comment: params[:comment],
+            symbols_file: params[:mapping],
+          )
+        else
+          UI.message("Not uploading #{params[:file_path]} as we're not on CI.")
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Upload the given file to TestFairy"
+      end
+
+      def self.details
+        "
+        You need to pass custom distribution groups to properly target audiences.
+        Note that it only runs on CI.
+        "
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :api_key,
+            env_name: "TESTFAIRY_ACCESS_KEY",
+            description: "The upload API token to interact with TestFairy APIs",
+            is_string: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :apk,
+            description: "The path to the your Android APK file",
+            is_string: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :mapping,
+            description: "The path to the your Android APK mapping file",
+            is_string: true,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :comment,
+            description: "The changelog for this release",
+            is_string: true,
+            optional: true,
+            default_value: Actions.lane_context[SharedValues::CHANGELOG_MARKDOWN_PUBLIC]
+          )
+        ]
+      end
+
+      def self.authors
+        ["fueled"]
+      end
+
+      def self.is_supported?(platform)
+        [:android].include?(platform)
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/fueled/actions/upload_to_test_fairy_ios.rb
+++ b/lib/fastlane/plugin/fueled/actions/upload_to_test_fairy_ios.rb
@@ -1,0 +1,74 @@
+require_relative '../helper/fueled_helper'
+
+module Fastlane
+  module Actions
+    module SharedValues
+    end
+
+    class UploadToTestFairyIosAction < Action
+      def self.run(params)
+        if other_action.is_ci
+          other_action.testfairy(
+            api_key: params[:api_key],
+            ipa: params[:ipa],
+            comment: params[:comment],
+            symbols_file: params[:dsym],
+          )
+        else
+          UI.message("Not uploading #{params[:file_path]} as we're not on CI.")
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Upload the given file to TestFairy"
+      end
+
+      def self.details
+        "
+        Note that it only runs on CI.
+        "
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :api_key,
+            env_name: "TESTFAIRY_ACCESS_KEY",
+            description: "The upload API token to interact with TestFairy APIs",
+            is_string: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :ipa,
+            description: "The path to the your iOS IPA file",
+            is_string: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :comment,
+            description: "The changelog for this release",
+            is_string: true,
+            optional: true,
+            default_value: Actions.lane_context[SharedValues::CHANGELOG_MARKDOWN_PUBLIC]
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :dsym,
+            description: "The path to the your iOS IPA dysm file",
+            is_string: true,
+            optional: true
+          ),
+        ]
+      end
+
+      def self.authors
+        ["fueled"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios].include?(platform)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add support for TestFairy (distribution platform)
- Update readme accordingly

Attached is proof of functionality:
![image](https://github.com/Fueled/fastlane-plugin-fueled/assets/4731572/fc57f81f-09ac-4360-8fa7-58bba3043326)
