### PR TITLE
fix(ios-build-number): filter build number tag by build_type

### DIFF
--- a/lib/fastlane/plugin/fueled/actions/define_versions_ios.rb
+++ b/lib/fastlane/plugin/fueled/actions/define_versions_ios.rb
@@ -10,7 +10,7 @@ module Fastlane
     class DefineVersionsIosAction < Action
       def self.run(params)
         # Build Number
-        Actions.lane_context[SharedValues::FUELED_BUILD_NUMBER] = Helper::FueledHelper.new_build_number(filter: '')
+        Actions.lane_context[SharedValues::FUELED_BUILD_NUMBER] = Helper::FueledHelper.new_build_number(filter: params[:build_type])
         # Short Version
         current_short_version = Helper::FueledHelper.short_version_ios(
           project_path: params[:project_path],


### PR DESCRIPTION
When fetching the build number on iOS, we are neglecting to pass the `build_type` param which if provided will filter the tags based on environment.

Currently: with no filter provided, the most recent build number is fetched and incremented regardless of the environment. 

```
**Start**
Production/Snapshot-100
...
Snapshot-101
Snapshot-102
Production-103
Snapshot-104
Production-105
```

Expected behavior: build numbers should increment based on their respective environments

```
**Start**
Production/Snapshot-100
...
Snapshot-101
Snapshot-102
Production-101
Snapshot-103
Production-102
```