### PR TITLE
chore(flutter): use concurrency to improve flutter tests

### DIFF
--- a/fastlane-plugin-fueled.gemspec
+++ b/fastlane-plugin-fueled.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('fastlane-plugin-appcenter', '~> 2.0.0')
   spec.add_dependency('fastlane-plugin-versioning', '~> 0.5.0')
-
+  spec.add_dependency('concurrent-ruby')
   spec.add_development_dependency('bundler')
   spec.add_development_dependency('fastlane', '>= 2.197.0')
   spec.add_development_dependency('pry')

--- a/lib/fastlane/plugin/fueled/actions/unit_tests_flutter.rb
+++ b/lib/fastlane/plugin/fueled/actions/unit_tests_flutter.rb
@@ -1,3 +1,5 @@
+require 'concurrent'
+
 module Fastlane
     module Actions
       module SharedValues
@@ -11,7 +13,11 @@ module Fastlane
           sh("./scripts/code_coverage_helper.sh") #TODO: incorporate the code from `code_coverage_helper.sh` into this action once this issue has been resolved https://github.com/flutter/flutter/issues/27997
           UI.message("Running unit tests")
           sh("rm -rf coverage")
-          sh("flutter test --coverage")
+
+          cpu_cores = Concurrent.physical_processor_count
+          coverage_cmd ="flutter test --coverage --concurrency=#{cpu_cores}"
+          sh(coverage_cmd)
+
           sh("genhtml -o coverage coverage/lcov.info")
           sh("flutter test test/essentials.dart")
         end


### PR DESCRIPTION
Flutter tests can run more efficiently if we leverage [the concurrency parameter](https://pub.dev/packages/test#test-concurrency). This is by default set to half of whatever cores there are on the machine. 

This PR updates it to use all cores in an attempt to run as many tests as possible in parallel.

I've seen improvements of over 38% in the test command when I ran it for meow wolf
With concurrency parameter : 42s 
Without concurrency parameter : 58s