### PR TITLE
chore(reports): ensure we use github as the default reporter

### DIFF
--- a/lib/fastlane/plugin/fueled/actions/unit_tests_flutter.rb
+++ b/lib/fastlane/plugin/fueled/actions/unit_tests_flutter.rb
@@ -15,7 +15,7 @@ module Fastlane
           sh("rm -rf coverage")
 
           cpu_cores = Concurrent.physical_processor_count
-          coverage_cmd ="flutter test --coverage --concurrency=#{cpu_cores}"
+          coverage_cmd ="flutter test --coverage --reporter=github --concurrency=#{cpu_cores}"
           sh(coverage_cmd)
 
           sh("genhtml -o coverage coverage/lcov.info")


### PR DESCRIPTION
Github reporter is more concise than the default reporter

Old Reporter
<img src="https://github.com/Fueled/fastlane-plugin-fueled/assets/1428864/9e0c3286-a7b8-4e49-9cbc-5e96bac7f3c3" width=500 alt="Default Reporter"/><br/>

Github Reporter
<img src="https://github.com/Fueled/fastlane-plugin-fueled/assets/1428864/583abe33-0bf8-4ac8-bb8e-55db93f8f130" width=500/ alt="Github Reporter"/>
