### PR TITLE
chore(flutter): update actions to remove easy localization + integration tests

### DIFF
--- a/lib/fastlane/plugin/fueled/actions/formatting_checks_flutter.rb
+++ b/lib/fastlane/plugin/fueled/actions/formatting_checks_flutter.rb
@@ -7,7 +7,7 @@ module Fastlane
       def self.run(params)
         UI.message("Checking formatting")
         sh("flutter pub get")
-        filesToFormat = "find lib test integration_test -name \"*.dart\" -not \\( -name \"*.*freezed.dart\" -o -name \"*.g.dart\" -o -name \"*.gen.dart\" -o -name \"*.mocks.dart\" \\)"
+        filesToFormat = "find lib test -name \"*.dart\" -not \\( -name \"*.*freezed.dart\" -o -name \"*.g.dart\" -o -name \"*.gen.dart\" -o -name \"*.mocks.dart\" \\)"
         sh("dart format $(#{filesToFormat}) -o none --set-exit-if-changed")
       end
 

--- a/lib/fastlane/plugin/fueled/actions/generate_files_flutter.rb
+++ b/lib/fastlane/plugin/fueled/actions/generate_files_flutter.rb
@@ -17,29 +17,10 @@ module Fastlane
           cmd = "cd #{path} && "
           cmd += "flutter pub get && "
           cmd += "dart run build_runner build --verbose --delete-conflicting-outputs --define \"dynamic_config_generator|config_builder=variant=#{variant}\""
-          if !params[:skip_localization] && check_localization_package(path)
-            cmd += " && echo \"Generating Localization files \""
-            cmd += " && dart run easy_localization:generate -S \"assets/translations\" -O \"lib/gen\""
-            cmd += " && dart run easy_localization:generate -S \"assets/translations\" -O \"lib/gen\" -o \"locale_keys.g.dart\" -f keys"
-          end
           sh(cmd)
         end
       end
 
-      def self.check_localization_package(folder_path)
-        localization_package = "easy_localization"
-        pubspec_file = File.join(folder_path, 'pubspec.yaml')
-        if File.exist?(pubspec_file)
-          content = File.read(pubspec_file)
-          if content.include?(localization_package)
-            return true
-          else
-            return false
-          end
-        else
-          false
-        end
-      end
       #####################################################
       # @!group Documentation
       #####################################################

--- a/lib/fastlane/plugin/fueled/version.rb
+++ b/lib/fastlane/plugin/fueled/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Fueled
-    VERSION = "0.3.2"
+    VERSION = "0.3.3"
   end
 end


### PR DESCRIPTION
[Easy localization is no longer used on Flutter](https://github.com/Fueled/project-template-flutter/pull/78), and we also [removed integration tests](https://github.com/Fueled/project-template-flutter/pull/76/commits/ba3e213a3267e994949d1ff782328b502b911a40) from the template 