### PR TITLE
Auto-sync project capabilities and recreate profiles on mismatch

### DIFF
--- a/lib/fastlane/plugin/fueled/library/app_store_connect/api.rb
+++ b/lib/fastlane/plugin/fueled/library/app_store_connect/api.rb
@@ -581,6 +581,26 @@ module Fastlane
           response['data'] || []
         end
 
+        # Default capability settings required by App Store Connect when enabling
+        # certain capability types. Most capabilities accept an empty settings array,
+        # but a few — like Sign in with Apple — require an explicit configuration or
+        # the API rejects the enable call with:
+        #
+        #   "Please select at least one configuration for Sign In with Apple."
+        #
+        # For Sign in with Apple we default to enabling the App ID as the primary
+        # consent target (equivalent to ticking "Enable as a primary App ID" in
+        # the developer portal). Apps that need to be grouped with an existing
+        # primary App ID should configure this manually.
+        CAPABILITY_DEFAULT_SETTINGS = {
+          'APPLE_ID_AUTH' => [
+            {
+              key: 'APPLE_ID_AUTH_APP_CONSENT',
+              options: [{ key: 'PRIMARY_APP_CONSENT' }]
+            }
+          ]
+        }.freeze
+
         # Enable a capability on a bundle ID
         def enable_bundle_id_capability(key_id: nil, issuer_id: nil, key_content: nil, key_file_path: nil, bundle_id_id:, capability_type:)
           body = {
@@ -588,7 +608,7 @@ module Fastlane
               type: 'bundleIdCapabilities',
               attributes: {
                 capabilityType: capability_type,
-                settings: []
+                settings: CAPABILITY_DEFAULT_SETTINGS[capability_type] || []
               },
               relationships: {
                 bundleId: {

--- a/lib/fastlane/plugin/fueled/library/app_store_connect/api.rb
+++ b/lib/fastlane/plugin/fueled/library/app_store_connect/api.rb
@@ -565,6 +565,56 @@ module Fastlane
         end
 
         # ---------------------------------------------
+        # Bundle ID Capabilities
+        # ---------------------------------------------
+
+        # Fetch capabilities enabled on a bundle ID
+        def fetch_bundle_id_capabilities(key_id: nil, issuer_id: nil, key_content: nil, key_file_path: nil, bundle_id_id:)
+          response = request(
+            key_id: key_id,
+            issuer_id: issuer_id,
+            key_content: key_content,
+            key_file_path: key_file_path,
+            path: "/bundleIds/#{bundle_id_id}/bundleIdCapabilities"
+          )
+
+          response['data'] || []
+        end
+
+        # Enable a capability on a bundle ID
+        def enable_bundle_id_capability(key_id: nil, issuer_id: nil, key_content: nil, key_file_path: nil, bundle_id_id:, capability_type:)
+          body = {
+            data: {
+              type: 'bundleIdCapabilities',
+              attributes: {
+                capabilityType: capability_type,
+                settings: []
+              },
+              relationships: {
+                bundleId: {
+                  data: {
+                    type: 'bundleIds',
+                    id: bundle_id_id
+                  }
+                }
+              }
+            }
+          }
+
+          response = request(
+            key_id: key_id,
+            issuer_id: issuer_id,
+            key_content: key_content,
+            key_file_path: key_file_path,
+            method: :post,
+            path: '/bundleIdCapabilities',
+            body: body
+          )
+
+          response['data']
+        end
+
+        # ---------------------------------------------
         # Users
         # ---------------------------------------------
         # Fetch the team ID for a specific bundle ID

--- a/lib/fastlane/plugin/fueled/library/app_store_connect/api.rb
+++ b/lib/fastlane/plugin/fueled/library/app_store_connect/api.rb
@@ -394,7 +394,7 @@ module Fastlane
                 
                 if matches
                   filtered << profile
-                elsif UI.verbose?
+                elsif FastlaneCore::Globals.verbose?
                   UI.verbose("Profile '#{profile_name}' (ID: #{profile_id}) has bundle ID: #{bundle_id_in_profile.inspect}, looking for: #{bundle_id_id}")
                 end
               end

--- a/lib/fastlane/plugin/fueled/library/apple_dev_portal/profiles/profile_helper.rb
+++ b/lib/fastlane/plugin/fueled/library/apple_dev_portal/profiles/profile_helper.rb
@@ -65,6 +65,52 @@ module Fastlane
             end
             normalized
           end
+
+          # Extract entitlements from an installed provisioning profile on disk
+          def extract_entitlements_from_profile(profile_uuid)
+            return {} unless profile_uuid
+
+            profile_path = File.expand_path("~/Library/MobileDevice/Provisioning Profiles/#{profile_uuid}.mobileprovision")
+            return {} unless File.exist?(profile_path)
+
+            begin
+              plist_xml = `security cms -D -i "#{profile_path}" 2>/dev/null`
+              return {} unless $?.success? && !plist_xml.strip.empty?
+
+              plist = Plist.parse_xml(plist_xml)
+              return {} unless plist
+
+              plist['Entitlements'] || {}
+            rescue StandardError => e
+              UI.important("Could not extract entitlements from profile #{profile_uuid}: #{e.message}")
+              {}
+            end
+          end
+
+          # Compare project entitlements against profile entitlements.
+          # Returns a mismatch description if the project requires capabilities
+          # the profile doesn't provide; nil otherwise.
+          # Extra capabilities in the profile are harmless and ignored.
+          def check_entitlements_mismatch(project_path:, profile_uuid:)
+            project_ents = normalize_entitlements(extract_entitlements_from_project(project_path))
+            profile_ents = normalize_entitlements(extract_entitlements_from_profile(profile_uuid))
+
+            return nil if project_ents.empty? || profile_ents.empty?
+
+            missing = []
+            project_ents.each_key do |key|
+              next if profile_ents.key?(key)
+              # For aps-environment, presence is what matters — value differs
+              # between debug (development) and release (production) builds
+              next if key == 'aps-environment' && profile_ents.key?('aps-environment')
+
+              missing << key
+            end
+
+            return nil if missing.empty?
+
+            "project requires entitlements missing from profile: #{missing.join(', ')}"
+          end
         end
       end
     end

--- a/lib/fastlane/plugin/fueled/library/apple_dev_portal/profiles/profile_helper.rb
+++ b/lib/fastlane/plugin/fueled/library/apple_dev_portal/profiles/profile_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'plist'
+require 'set'
+require_relative '../../app_store_connect/api'
 require 'fastlane_core/ui/ui'
 
 module Fastlane
@@ -8,7 +10,84 @@ module Fastlane
     module AppleDevPortal
       module Profiles
         module ProfileHelper
+          # Maps Xcode entitlement keys to App Store Connect capability types.
+          # When the project requires an entitlement that the App ID doesn't have,
+          # the plugin uses this mapping to enable the capability automatically.
+          ENTITLEMENT_TO_CAPABILITY = {
+            'com.apple.developer.associated-domains' => 'ASSOCIATED_DOMAINS',
+            'aps-environment' => 'PUSH_NOTIFICATIONS',
+            'com.apple.developer.applesignin' => 'APPLE_ID_AUTH',
+            'com.apple.security.application-groups' => 'APP_GROUPS',
+            'com.apple.developer.icloud-container-identifiers' => 'ICLOUD',
+            'com.apple.developer.icloud-services' => 'ICLOUD',
+            'com.apple.developer.default-data-protection' => 'DATA_PROTECTION',
+            'com.apple.developer.healthkit' => 'HEALTHKIT',
+            'com.apple.developer.healthkit.access' => 'HEALTHKIT',
+            'com.apple.developer.homekit' => 'HOMEKIT',
+            'com.apple.developer.networking.multipath' => 'MULTIPATH',
+            'com.apple.developer.networking.networkextension' => 'NETWORK_EXTENSIONS',
+            'com.apple.developer.nfc.readersession.formats' => 'NFC_TAG_READING',
+            'com.apple.developer.siri' => 'SIRI',
+            'com.apple.developer.pass-type-identifiers' => 'WALLET',
+            'com.apple.developer.networking.wifi-info' => 'ACCESS_WIFI_INFORMATION',
+            'com.apple.developer.game-center' => 'GAME_CENTER',
+            'com.apple.developer.maps' => 'MAPS',
+            'com.apple.developer.in-app-payments' => 'APPLE_PAY',
+            'com.apple.developer.ClassKit-environment' => 'CLASSKIT',
+            'com.apple.developer.networking.HotspotConfiguration' => 'HOT_SPOT',
+            'com.apple.developer.usernotifications.communication' => 'USER_MANAGEMENT',
+            'com.apple.developer.group-session' => 'GROUP_ACTIVITIES',
+          }.freeze
+
           module_function
+
+          # Sync project entitlements to App Store Connect by enabling
+          # any capabilities the project requires but the App ID lacks.
+          #
+          # Call this before creating a new provisioning profile so the
+          # profile will include the correct entitlements.
+          def sync_capabilities_to_portal(project_path:, bundle_id_id:, key_id: nil, issuer_id: nil, key_content: nil, key_file_path: nil)
+            project_ents = extract_entitlements_from_project(project_path)
+            return if project_ents.empty?
+
+            # Determine which capability types the project needs
+            needed_types = Set.new
+            project_ents.each_key do |entitlement_key|
+              capability_type = ENTITLEMENT_TO_CAPABILITY[entitlement_key]
+              needed_types << capability_type if capability_type
+            end
+            return if needed_types.empty?
+
+            # Fetch current capabilities from the portal
+            current_capabilities = AppStoreConnect::API.fetch_bundle_id_capabilities(
+              key_id: key_id,
+              issuer_id: issuer_id,
+              key_content: key_content,
+              key_file_path: key_file_path,
+              bundle_id_id: bundle_id_id
+            )
+            current_types = Set.new(current_capabilities.map { |c| c.dig('attributes', 'capabilityType') }.compact)
+
+            missing_types = needed_types - current_types
+            return if missing_types.empty?
+
+            UI.message("Enabling #{missing_types.length} missing capability(ies) on App ID...")
+            missing_types.each do |capability_type|
+              begin
+                AppStoreConnect::API.enable_bundle_id_capability(
+                  key_id: key_id,
+                  issuer_id: issuer_id,
+                  key_content: key_content,
+                  key_file_path: key_file_path,
+                  bundle_id_id: bundle_id_id,
+                  capability_type: capability_type
+                )
+                UI.success("  ✓ Enabled #{capability_type}")
+              rescue StandardError => e
+                UI.important("  ⚠ Could not enable #{capability_type}: #{e.message}")
+              end
+            end
+          end
 
           # Generate a profile name based on bundle ID and type
           def generate_profile_name(bundle_id, profile_type)
@@ -73,8 +152,34 @@ module Fastlane
             profile_path = File.expand_path("~/Library/MobileDevice/Provisioning Profiles/#{profile_uuid}.mobileprovision")
             return {} unless File.exist?(profile_path)
 
+            extract_entitlements_from_mobileprovision(profile_path)
+          end
+
+          # Extract entitlements from raw mobileprovision data (bytes).
+          # Writes to a temp file and uses `security cms -D` to decode.
+          def extract_entitlements_from_profile_data(raw_data)
+            return {} unless raw_data && !raw_data.empty?
+
+            require 'tempfile'
+
+            tmpfile = Tempfile.new(['profile', '.mobileprovision'])
             begin
-              plist_xml = `security cms -D -i "#{profile_path}" 2>/dev/null`
+              tmpfile.binmode
+              tmpfile.write(raw_data)
+              tmpfile.close
+
+              extract_entitlements_from_mobileprovision(tmpfile.path)
+            ensure
+              tmpfile.close! rescue nil
+            end
+          end
+
+          # Extract entitlements from a mobileprovision file at the given path
+          def extract_entitlements_from_mobileprovision(path)
+            return {} unless path && File.exist?(path)
+
+            begin
+              plist_xml = `security cms -D -i "#{path}" 2>/dev/null`
               return {} unless $?.success? && !plist_xml.strip.empty?
 
               plist = Plist.parse_xml(plist_xml)
@@ -82,7 +187,7 @@ module Fastlane
 
               plist['Entitlements'] || {}
             rescue StandardError => e
-              UI.important("Could not extract entitlements from profile #{profile_uuid}: #{e.message}")
+              UI.important("Could not extract entitlements from profile at #{path}: #{e.message}")
               {}
             end
           end
@@ -91,11 +196,34 @@ module Fastlane
           # Returns a mismatch description if the project requires capabilities
           # the profile doesn't provide; nil otherwise.
           # Extra capabilities in the profile are harmless and ignored.
-          def check_entitlements_mismatch(project_path:, profile_uuid:)
+          #
+          # When the profile is not on disk (e.g. fresh CI), falls back to
+          # downloading profile content from the App Store Connect API if
+          # credentials and profile_id are provided.
+          def check_entitlements_mismatch(project_path:, profile_uuid:, key_id: nil, issuer_id: nil, key_content: nil, key_file_path: nil, profile_id: nil)
             project_ents = normalize_entitlements(extract_entitlements_from_project(project_path))
+            return nil if project_ents.empty?
+
             profile_ents = normalize_entitlements(extract_entitlements_from_profile(profile_uuid))
 
-            return nil if project_ents.empty? || profile_ents.empty?
+            # If profile is not on disk, try downloading from ASC API
+            if profile_ents.empty? && profile_id
+              UI.message("Profile not found on disk, downloading from App Store Connect to check entitlements...")
+              begin
+                raw_data = AppStoreConnect::API.download_profile(
+                  key_id: key_id,
+                  issuer_id: issuer_id,
+                  key_content: key_content,
+                  key_file_path: key_file_path,
+                  profile_id: profile_id
+                )
+                profile_ents = normalize_entitlements(extract_entitlements_from_profile_data(raw_data))
+              rescue StandardError => e
+                UI.important("Could not download profile for entitlement check: #{e.message}")
+              end
+            end
+
+            return nil if profile_ents.empty?
 
             missing = []
             project_ents.each_key do |key|

--- a/lib/fastlane/plugin/fueled/library/apple_dev_portal/profiles/profile_manager.rb
+++ b/lib/fastlane/plugin/fueled/library/apple_dev_portal/profiles/profile_manager.rb
@@ -149,10 +149,11 @@ module Fastlane
                 bundle_id: bundle_id,
                 profile_type: profile_type,
                 bundle_id_id: bundle_id_id,
-                  key_id: key_id,
-                  issuer_id: issuer_id,
-                  key_content: key_content,
-                key_file_path: key_file_path
+                key_id: key_id,
+                issuer_id: issuer_id,
+                key_content: key_content,
+                key_file_path: key_file_path,
+                project_path: project_path
               )
 
               best_profile = selection_result[:best_profile]
@@ -276,7 +277,8 @@ module Fastlane
                     key_id: key_id,
                     issuer_id: issuer_id,
                     key_content: key_content,
-                    key_file_path: key_file_path
+                    key_file_path: key_file_path,
+                    project_path: project_path
                   )
 
                   best_profile = selection_result[:best_profile]

--- a/lib/fastlane/plugin/fueled/library/apple_dev_portal/profiles/profile_manager.rb
+++ b/lib/fastlane/plugin/fueled/library/apple_dev_portal/profiles/profile_manager.rb
@@ -225,15 +225,28 @@ module Fastlane
             end
 
             UI.message("No existing profile found. Creating new profile: #{resolved_profile_name}")
-            
+
             unless bundle_id_id
               UI.user_error!("Bundle ID ID is required to create a provisioning profile")
             end
-            
+
             unless resolved_certificate_id
               UI.user_error!("Certificate ID is required to create a provisioning profile")
             end
-            
+
+            # Sync project capabilities to the App ID before creating the profile,
+            # so the new profile will include all required entitlements.
+            if project_path
+              ProfileHelper.sync_capabilities_to_portal(
+                project_path: project_path,
+                bundle_id_id: bundle_id_id,
+                key_id: key_id,
+                issuer_id: issuer_id,
+                key_content: key_content,
+                key_file_path: key_file_path
+              )
+            end
+
             UI.message("Creating profile with bundle ID: #{bundle_id_id}, certificate: #{resolved_certificate_id}")
 
             begin

--- a/lib/fastlane/plugin/fueled/library/apple_dev_portal/profiles/profile_selector.rb
+++ b/lib/fastlane/plugin/fueled/library/apple_dev_portal/profiles/profile_selector.rb
@@ -24,7 +24,7 @@ module Fastlane
           # - key_id, issuer_id, key_content, key_file_path: App Store Connect credentials
           #
           # Returns: Hash with :best_profile, :profiles_to_delete, :best_profile_valid
-          def select_best(existing_profiles:, bundle_id:, profile_type:, bundle_id_id:, key_id: nil, issuer_id: nil, key_content: nil, key_file_path: nil)
+          def select_best(existing_profiles:, bundle_id:, profile_type:, bundle_id_id:, key_id: nil, issuer_id: nil, key_content: nil, key_file_path: nil, project_path: nil)
             return { best_profile: nil, profiles_to_delete: [], best_profile_valid: false } if existing_profiles.empty?
 
             if existing_profiles.length > 1
@@ -46,6 +46,7 @@ module Fastlane
               profile_id = p['id']
               profile_attrs = p['attributes'] || {}
               profile_expiration_date = profile_attrs['expirationDate']
+              profile_uuid = profile_attrs['uuid']
               profile_certificate_ids = p.dig('relationships', 'certificates', 'data')&.map { |c| c['id'] } || []
 
               validation_result = ProfileValidator.validate(
@@ -56,7 +57,9 @@ module Fastlane
                 profile_id: profile_id,
                 profile_expiration_date: profile_expiration_date,
                 profile_certificate_ids: profile_certificate_ids,
-                bundle_id_id: bundle_id_id
+                bundle_id_id: bundle_id_id,
+                project_path: project_path,
+                profile_uuid: profile_uuid
               )
 
               if validation_result[:needs_update]

--- a/lib/fastlane/plugin/fueled/library/apple_dev_portal/profiles/profile_validator.rb
+++ b/lib/fastlane/plugin/fueled/library/apple_dev_portal/profiles/profile_validator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../app_store_connect/api'
+require_relative 'profile_helper'
 require 'fastlane_core/ui/ui'
 
 module Fastlane
@@ -20,7 +21,7 @@ module Fastlane
           # - bundle_id_id: String, bundle ID ID
           #
           # Returns: Hash with :needs_update (Boolean) and :reason (String)
-          def validate(key_id: nil, issuer_id: nil, key_content: nil, key_file_path: nil, profile_id:, profile_expiration_date:, profile_certificate_ids:, bundle_id_id:)
+          def validate(key_id: nil, issuer_id: nil, key_content: nil, key_file_path: nil, profile_id:, profile_expiration_date:, profile_certificate_ids:, bundle_id_id:, project_path: nil, profile_uuid: nil)
             reasons = []
 
             if profile_expiration_date
@@ -47,6 +48,14 @@ module Fastlane
                   reasons << "certificate #{cert_id} is invalid or expired"
                 end
               end
+            end
+
+            if project_path && profile_uuid
+              mismatch = ProfileHelper.check_entitlements_mismatch(
+                project_path: project_path,
+                profile_uuid: profile_uuid
+              )
+              reasons << "capability mismatch: #{mismatch}" if mismatch
             end
 
             {

--- a/lib/fastlane/plugin/fueled/library/apple_dev_portal/profiles/profile_validator.rb
+++ b/lib/fastlane/plugin/fueled/library/apple_dev_portal/profiles/profile_validator.rb
@@ -53,7 +53,12 @@ module Fastlane
             if project_path && profile_uuid
               mismatch = ProfileHelper.check_entitlements_mismatch(
                 project_path: project_path,
-                profile_uuid: profile_uuid
+                profile_uuid: profile_uuid,
+                key_id: key_id,
+                issuer_id: issuer_id,
+                key_content: key_content,
+                key_file_path: key_file_path,
+                profile_id: profile_id
               )
               reasons << "capability mismatch: #{mismatch}" if mismatch
             end


### PR DESCRIPTION
## Summary

- Detects when Xcode project entitlements don't match the provisioning profile's capabilities and automatically recreates the profile.
- Syncs missing capabilities to the App Store Connect App ID before creating new profiles, so the regenerated profile includes all required entitlements.
- Adds `fetch_bundle_id_capabilities` and `enable_bundle_id_capability` to the App Store Connect API client.
- Fixes a crash in `ensure_provisioning_profiles` when ASC ignores the `filter[bundleId]` parameter and the action falls back to client-side filtering — `UI.verbose?` was not a method on Fastlane's `UI` module; switched to `FastlaneCore::Globals.verbose?`.
- Sends the required `APPLE_ID_AUTH_APP_CONSENT` setting when enabling Sign in with Apple on a bundle ID. Previously the enable call was rejected with *"Please select at least one configuration for Sign In with Apple"* and left the App ID half-configured, blocking profile creation. Defaults to "Enable as a primary App ID".