### PR TITLE
[FIX] use FastlaneCore::Globals.verbose? instead of UI.verbose?

### DIFF
--- a/lib/fastlane/plugin/fueled/library/app_store_connect/api.rb
+++ b/lib/fastlane/plugin/fueled/library/app_store_connect/api.rb
@@ -394,7 +394,7 @@ module Fastlane
                 
                 if matches
                   filtered << profile
-                elsif UI.verbose?
+                elsif FastlaneCore::Globals.verbose?
                   UI.verbose("Profile '#{profile_name}' (ID: #{profile_id}) has bundle ID: #{bundle_id_in_profile.inspect}, looking for: #{bundle_id_id}")
                 end
               end


### PR DESCRIPTION
## Summary

- `UI.verbose?` is not a method on Fastlane's `UI` module, so `ensure_provisioning_profiles` crashes with `NoMethodError` right after the client-side bundle ID filtering step.
- Switch to `FastlaneCore::Globals.verbose?` which is the canonical way to check verbose mode in Fastlane.

## Repro

```
bundle exec fastlane run ensure_provisioning_profiles
```

Logs end with:
```
[!] Unknown method 'verbose?', supported [:header, :shell_error!, :build_failure!, :test_failure!, ...]
```

The error fires from `lib/fastlane/plugin/fueled/library/app_store_connect/api.rb:397` once the action falls back to client-side filtering (i.e. whenever the ASC API doesn't honor the bundle ID filter).