### PR TITLE
[FIX] auto-configure Sign in with Apple as primary App ID

### DIFF
--- a/lib/fastlane/plugin/fueled/library/app_store_connect/api.rb
+++ b/lib/fastlane/plugin/fueled/library/app_store_connect/api.rb
@@ -581,6 +581,26 @@ module Fastlane
           response['data'] || []
         end
 
+        # Default capability settings required by App Store Connect when enabling
+        # certain capability types. Most capabilities accept an empty settings array,
+        # but a few — like Sign in with Apple — require an explicit configuration or
+        # the API rejects the enable call with:
+        #
+        #   "Please select at least one configuration for Sign In with Apple."
+        #
+        # For Sign in with Apple we default to enabling the App ID as the primary
+        # consent target (equivalent to ticking "Enable as a primary App ID" in
+        # the developer portal). Apps that need to be grouped with an existing
+        # primary App ID should configure this manually.
+        CAPABILITY_DEFAULT_SETTINGS = {
+          'APPLE_ID_AUTH' => [
+            {
+              key: 'APPLE_ID_AUTH_APP_CONSENT',
+              options: [{ key: 'PRIMARY_APP_CONSENT' }]
+            }
+          ]
+        }.freeze
+
         # Enable a capability on a bundle ID
         def enable_bundle_id_capability(key_id: nil, issuer_id: nil, key_content: nil, key_file_path: nil, bundle_id_id:, capability_type:)
           body = {
@@ -588,7 +608,7 @@ module Fastlane
               type: 'bundleIdCapabilities',
               attributes: {
                 capabilityType: capability_type,
-                settings: []
+                settings: CAPABILITY_DEFAULT_SETTINGS[capability_type] || []
               },
               relationships: {
                 bundleId: {


### PR DESCRIPTION
## Summary

- The plugin enables capabilities on a bundle ID with `settings: []`, which works for most capability types but not for Sign in with Apple. `APPLE_ID_AUTH` requires an explicit `APPLE_ID_AUTH_APP_CONSENT` setting; without it the ASC API rejects the request with *"Please select at least one configuration for Sign In with Apple"* and leaves the App ID half-configured.
- Add a `CAPABILITY_DEFAULT_SETTINGS` map and default `APPLE_ID_AUTH` to "primary App ID" (the most common setup, equivalent to ticking *Enable as a primary App ID* in the developer portal).
- Other capabilities that need settings (e.g. App Groups, iCloud containers, Merchant IDs) can be added to the same map as we hit them.

## Repro

A project whose entitlements include `com.apple.developer.applesignin` hits this on the first run of `ensure_provisioning_profiles` against a fresh bundle ID:

```
Enabling 2 missing capability(ies) on App ID...
  ⚠ Could not enable APPLE_ID_AUTH: [ASC ERROR] Please select at least one configuration for Sign In with Apple.
  ✓ Enabled ASSOCIATED_DOMAINS
```

After this PR, the App ID is created with Sign in with Apple already configured as primary and no manual step in the dev portal is needed.